### PR TITLE
Move remainder of rust-rgb20 into rgb-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "amplify"
-version = "3.12.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45c604e86700ffea68a7d90c3ffb1508dad1120902f31dbb08afc942cf8acf3"
+checksum = "116019a174e912931d5b19ca7ab6a22596d12cdb1320358fad3368f0aba135a9"
 dependencies = [
  "amplify_apfloat",
  "amplify_derive",
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_derive_helpers"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1031494858bb61a17feb9e51f0bc2d0a397d7fefa1f0a9e92f6e260912d51d7"
+checksum = "d8a2293d9a54744b73b753fad2e3c16295345504dc230696ee8aa5dbfd276ab4"
 dependencies = [
  "amplify",
  "proc-macro2",
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
 
 [[package]]
 name = "heck"
@@ -837,9 +837,9 @@ checksum = "4eae0151b9dacf24fcc170d9995e511669a082856a91f958a2fe380bfab3fb22"
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"
@@ -1127,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "rgb-core"
-version = "0.8.0-rc.5"
+version = "0.8.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9fdabcbd1090f83cf9d004075c2e3497e9aeadb4e40db6860b348dc504ffa77"
+checksum = "088f1be5a3cd638416ee4fe8da51c5fc1fa99c665b1baaead19a42daefe1c96f"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1242,18 +1242,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1306,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+checksum = "1ec0091e1f5aa338283ce049bd9dfefd55e1f168ac233e85c1ffe0038fb48cbe"
 dependencies = [
  "indexmap",
  "ryu",
@@ -1399,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "strict_encoding"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a0cffbeaff0c2b9981412ac471b7d99cb4adcff75a6967114ea36cd8faae930"
+checksum = "5a5fa61708f858144b37d2c10bafe95724dbc917f7ea491456d0069789f8f5f3"
 dependencies = [
  "amplify",
  "bitcoin",
@@ -1631,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
 dependencies = [
  "webpki",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "commit_verify"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,16 +1154,20 @@ dependencies = [
  "amplify",
  "bitcoin",
  "bp-core",
+ "chrono",
  "clap",
+ "colored",
  "commit_verify",
  "descriptor-wallet",
  "electrum-client",
+ "lnpbp",
  "lnpbp_bech32",
  "rgb-core",
  "serde",
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "stens",
  "strict_encoding",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "rgb-core"
-version = "0.8.0-rc.2"
+version = "0.8.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba54d26545b77f15d484e9854145bfb41c6428fd209241933d4237704c4eb77"
+checksum = "e9fdabcbd1090f83cf9d004075c2e3497e9aeadb4e40db6860b348dc504ffa77"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1371,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "stens"
-version = "0.5.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310f88dd6b45bd329abafc54869d476e9a7ad813b04adc162d62d6c5e94af46a"
+checksum = "6e4804a8a3d876fc0933294ff3d30c5353107ac88dfbab9d4283305b496c02ae"
 dependencies = [
  "amplify",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ descriptor-wallet = { version = "~0.8.1", features = ["descriptors"] }
 electrum-client = { version = "0.10.1", optional = true }
 lnpbp = "0.8.0"
 lnpbp_bech32 = "~0.8.0"
-rgb_core = { package = "rgb-core", version = "0.8.0-rc.5" }
+rgb_core = { package = "rgb-core", version = "0.8.0-rc.6" }
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 serde_with = { version = "1.8", features = ["hex"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,19 +23,23 @@ required-features = ["cli", "serde"]
 
 [dependencies]
 amplify = "3.12.1"
-lnpbp_bech32 = "~0.8.0"
-strict_encoding = { version = "~0.8.0", features = ["crypto", "chrono", "bitcoin"] }
-commit_verify = "~0.8.0"
-bp-core = { version = "~0.8.0-rc.1", features = ["wallet"] }
-rgb_core = { package = "rgb-core", version = "0.8.0-rc.5" }
-descriptor-wallet = { version = "~0.8.1", features = ["descriptors"] }
 bitcoin = "0.28.1"
+bp-core = { version = "~0.8.0-rc.1", features = ["wallet"] }
+chrono = "0.4"
+clap = { version = "~3.1.18", optional = true, features = ["derive", "env"] }
+colored = "2.0.0"
+commit_verify = "~0.8.0"
+descriptor-wallet = { version = "~0.8.1", features = ["descriptors"] }
 electrum-client = { version = "0.10.1", optional = true }
+lnpbp = "0.8.0"
+lnpbp_bech32 = "~0.8.0"
+rgb_core = { package = "rgb-core", version = "0.8.0-rc.5" }
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true }
 serde_with = { version = "1.8", features = ["hex"], optional = true }
 serde_yaml = { version = "0.8", optional = true }
-serde_json = { version = "1", optional = true }
-clap = { version = "~3.1.18", optional = true, features = ["derive"] }
+stens = "0.7.1"
+strict_encoding = { version = "~0.8.0", features = ["crypto", "chrono", "bitcoin"] }
 
 [dev-dependencies]
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ lnpbp_bech32 = "~0.8.0"
 strict_encoding = { version = "~0.8.0", features = ["crypto", "chrono", "bitcoin"] }
 commit_verify = "~0.8.0"
 bp-core = { version = "~0.8.0-rc.1", features = ["wallet"] }
-rgb_core = { package = "rgb-core", version = "0.8.0-rc.2" }
+rgb_core = { package = "rgb-core", version = "0.8.0-rc.5" }
 descriptor-wallet = { version = "~0.8.1", features = ["descriptors"] }
 bitcoin = "0.28.1"
 electrum-client = { version = "0.10.1", optional = true }

--- a/src/bin/rgb.rs
+++ b/src/bin/rgb.rs
@@ -15,6 +15,7 @@ extern crate clap;
 extern crate amplify;
 extern crate serde_crate as serde;
 
+use std::collections::BTreeMap;
 use std::fmt::{Debug, Display};
 use std::fs;
 use std::io::{self, Read};
@@ -26,11 +27,20 @@ use bitcoin::psbt::serialize::{Deserialize, Serialize};
 use bitcoin::OutPoint;
 use bp::seals::txout::CloseMethod;
 use clap::Parser;
+use colored::Colorize;
 use commit_verify::ConsensusCommit;
 use electrum_client::Client as ElectrumClient;
+use lnpbp::chain::Chain;
+use rgb::fungible::asset::Asset;
 use rgb::psbt::RgbExt;
-use rgb::{Disclosure, Extension, Schema, StateTransfer, Transition};
+use rgb::{
+    fungible::allocation::{AllocatedValue, OutpointValue, UtxobValue},
+    util::ticker_validator,
+    Consignment, Contract, Disclosure, Extension, IntoRevealedSeal, Schema, StateTransfer,
+    Transition,
+};
 use rgb_core::{seal, Validator};
+use stens::AsciiString;
 use strict_encoding::{StrictDecode, StrictEncode};
 use wallet::psbt::Psbt;
 
@@ -43,6 +53,10 @@ use wallet::psbt::Psbt;
     about = "Command-line tool for working with RGB smart contracts"
 )]
 pub struct Opts {
+    /// Bitcoin network to use
+    #[clap(short, long, default_value = "signet", env = "RGB_NETWORK")]
+    pub network: Chain,
+
     /// Command to execute
     #[clap(subcommand)]
     pub command: Command,
@@ -58,6 +72,62 @@ pub enum Command {
 
         /// Unspent transaction output to define as a blinded seal
         utxo: OutPoint,
+    },
+
+    /// Issue asset
+    Issue {
+        /// Asset ticker (up to 8 characters, always converted to uppercase)
+        #[clap(validator = ticker_validator)]
+        ticker: AsciiString,
+
+        /// Asset name (up to 32 characters)
+        name: AsciiString,
+
+        /// Precision, i.e. number of digits reserved for fractional part
+        #[clap(short, long, default_value = "8")]
+        precision: u8,
+
+        /// Asset allocation, in form of <amount>@<txid>:<vout>
+        allocation: Vec<OutpointValue>,
+
+        /// Outputs controlling inflation (secondary issue);
+        /// in form of <amount>@<txid>:<vout>
+        #[clap(short, long)]
+        inflation: Vec<OutpointValue>,
+
+        /// Enable renomination procedure; parameter takes argument in form of
+        /// <txid>:<vout> specifying output controlling renomination right
+        #[clap(short, long)]
+        renomination: Option<OutPoint>,
+
+        /// Enable epoch-based burn & replacement procedure; parameter takes
+        /// argument in form of <txid>:<vout> specifying output controlling the
+        /// right of opening the first epoch
+        #[clap(short, long)]
+        epoch: Option<OutPoint>,
+    },
+
+    /// Prepares state transition for assets transfer.
+    Transfer {
+        /// File with state transfer consignment, which endpoints will act as
+        /// inputs.
+        consignment: PathBuf,
+
+        /// Bitcoin transaction UTXOs which will be spent by the transfer
+        #[clap(short = 'u', long = "utxo", required = true)]
+        outpoints: Vec<OutPoint>,
+
+        /// List of transfer beneficiaries
+        #[clap(required = true)]
+        beneficiaries: Vec<UtxobValue>,
+
+        /// Change output; one per schema state type.
+        #[clap(short, long)]
+        change: Vec<AllocatedValue>,
+
+        /// File to store state transition transferring assets to the
+        /// beneficiaries and onto change outputs.
+        output: PathBuf,
     },
 
     /// Commands for working with consignments
@@ -250,7 +320,9 @@ impl FromStr for Format {
 }
 
 fn input_read<T>(data: Option<String>, format: Format) -> Result<T, Error>
-where T: StrictDecode + for<'de> serde::Deserialize<'de> {
+where
+    T: StrictDecode + for<'de> serde::Deserialize<'de>,
+{
     // TODO: Refactor with microservices cli
     let data = data
         .map(|d| d.as_bytes().to_vec())
@@ -300,9 +372,12 @@ where
 pub struct Error(Box<dyn std::error::Error>);
 
 impl<E> From<E> for Error
-where E: std::error::Error + 'static
+where
+    E: std::error::Error + 'static,
 {
-    fn from(e: E) -> Self { Error(Box::new(e)) }
+    fn from(e: E) -> Self {
+        Error(Box::new(e))
+    }
 }
 
 fn main() -> Result<(), Error> {
@@ -313,6 +388,88 @@ fn main() -> Result<(), Error> {
             let seal = seal::Revealed::new(method, utxo);
             println!("{}", seal.to_concealed_seal());
             println!("Blinding factor: {}", seal.blinding);
+        }
+
+        Command::Issue {
+            ticker,
+            name,
+            precision,
+            allocation,
+            inflation,
+            renomination,
+            epoch,
+        } => {
+            let inflation = inflation.into_iter().fold(
+                BTreeMap::new(),
+                |mut map, OutpointValue { value, outpoint }| {
+                    // We may have only a single secondary issuance right per
+                    // outpoint, so folding all outpoints
+                    map.entry(outpoint)
+                        .and_modify(|amount| *amount += value)
+                        .or_insert(value);
+                    map
+                },
+            );
+            let contract = Contract::create_rgb20(
+                opts.network,
+                ticker,
+                name,
+                precision,
+                allocation,
+                inflation,
+                renomination,
+                epoch,
+            );
+
+            let _asset =
+                Asset::try_from(&contract).expect("create_rgb20 does not match RGB20 schema");
+
+            eprintln!(
+                "{} {}\n",
+                "Contract ID:".bright_green(),
+                contract.contract_id().to_string().bright_yellow()
+            );
+
+            eprintln!("{}", "Contract YAML:".bright_green());
+            eprintln!("{}", serde_yaml::to_string(contract.genesis()).unwrap());
+
+            eprintln!("{}", "Contract JSON:".bright_green());
+            println!("{}\n", serde_json::to_string(contract.genesis()).unwrap());
+
+            eprintln!("{}", "Contract source:".bright_green());
+            println!("{}\n", contract);
+
+            // eprintln!("{}", "Asset details:".bright_green());
+            // eprintln!("{}\n", serde_yaml::to_string(&asset).unwrap());
+        }
+
+        Command::Transfer {
+            consignment,
+            outpoints,
+            beneficiaries,
+            change,
+            output,
+        } => {
+            let transfer = StateTransfer::strict_file_load(consignment).unwrap();
+
+            let asset = Asset::try_from(&transfer).unwrap();
+
+            let beneficiaries = beneficiaries
+                .into_iter()
+                .map(|v| (v.seal_confidential.into(), v.value))
+                .collect();
+            let change = change
+                .into_iter()
+                .map(|v| (v.into_revealed_seal(), v.value))
+                .collect();
+            let outpoints = outpoints.into_iter().collect();
+            let transition = asset.transfer(outpoints, beneficiaries, change).unwrap();
+
+            transition.strict_file_save(output).unwrap();
+            //consignment.strict_file_save(output).unwrap();
+
+            println!("{}", serde_yaml::to_string(&transition).unwrap());
+            println!("{}", "Success".bold().bright_green());
         }
 
         Command::Consignment { subcommand } => match subcommand {

--- a/src/fungible/asset.rs
+++ b/src/fungible/asset.rs
@@ -1,0 +1,114 @@
+// RGB20 Library: high-level API to RGB fungible assets.
+// Written in 2019-2022 by
+//     Dr. Maxim Orlovsky <orlovsky@lnp-bp.org>
+//
+// To the extent possible under law, the author(s) have dedicated all copyright
+// and related and neighboring rights to this software to the public domain
+// worldwide. This software is distributed without any warranty.
+//
+// You should have received a copy of the MIT License along with this software.
+// If not, see <https://opensource.org/licenses/MIT>.
+
+use std::collections::btree_set;
+
+use bitcoin::OutPoint;
+
+use crate::{
+    fungible::schema::schema, ConsignmentType, ContractState, InmemConsignment, NodeId, OwnedValue,
+};
+
+/// RGB20 asset information.
+///
+/// Structure presents complete set of RGB20 asset-related data which can be
+/// extracted from the genesis or a consignment. It is not the source of the
+/// truth, and the presence of the data in the structure does not imply their
+/// validity, since the structure constructor does not validates blockchain or
+/// LN-based transaction commitments or satisfaction of schema requirements.
+///
+/// The main reason of the structure is:
+/// 1) to persist *cached* copy of the asset data without the requirement to
+///    parse all stash transition each time in order to extract allocation
+///    information;
+/// 2) to present data from asset genesis or consignment for UI in convenient
+///    form.
+/// 3) to orchestrate generation of new state transitions taking into account
+///    known asset information.
+///
+/// (1) is important for wallets, (2) is for more generic software, like
+/// client-side-validated data explorers, developer & debugging tools etc and
+/// (3) for asset-management software.
+///
+/// In both (2) and (3) case there is no need to persist the structure; genesis
+/// /consignment should be persisted instead and the structure must be
+/// reconstructed each time from that data upon the launch
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
+#[derive(StrictEncode, StrictDecode)]
+pub struct Asset(ContractState);
+
+impl Asset {
+    /// Lists all known allocations for the given bitcoin transaction
+    /// [`OutPoint`]
+    pub fn known_coins(&self) -> btree_set::Iter<OwnedValue> {
+        self.0.owned_values.iter()
+    }
+
+    /// Lists all known allocations for the given bitcoin transaction
+    /// [`OutPoint`]
+    pub fn outpoint_coins(&self, outpoint: OutPoint) -> Vec<OwnedValue> {
+        self.known_coins()
+            .filter(|a| a.seal == outpoint)
+            .cloned()
+            .collect()
+    }
+}
+
+impl<T> TryFrom<&InmemConsignment<T>> for Asset
+where
+    T: ConsignmentType,
+{
+    type Error = Error;
+
+    fn try_from(consignment: &InmemConsignment<T>) -> Result<Self, Self::Error> {
+        let state = ContractState::from(consignment);
+        let asset = Asset(state);
+        asset.validate()?;
+        Ok(asset)
+    }
+}
+
+impl Asset {
+    fn validate(&self) -> Result<(), Error> {
+        if self.0.schema_id != schema().schema_id() {
+            Err(Error::WrongSchemaId)?;
+        }
+        // TODO: Validate the state
+        Ok(())
+    }
+}
+
+/// Errors generated during RGB20 asset information parsing from the underlying
+/// genesis or consignment data
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Display, From, Error)]
+#[display(doc_comments)]
+pub enum Error {
+    /// genesis schema id does not match any of RGB20 schemata
+    WrongSchemaId,
+
+    /// genesis defines a seal referencing witness transaction while there
+    /// can't be a witness transaction for genesis
+    GenesisSeal,
+
+    /// epoch seal definition for node {0} contains confidential data
+    EpochSealConfidential(NodeId),
+
+    /// nurn & replace seal definition for node {0} contains confidential data
+    BurnSealConfidential(NodeId),
+
+    /// inflation assignment (seal or state) for node {0} contains confidential
+    /// data
+    InflationAssignmentConfidential(NodeId),
+
+    /// not of all epochs referenced in burn or burn & replace operation
+    /// history are known from the consignment
+    NotAllEpochsExposed,
+}

--- a/src/fungible/create.rs
+++ b/src/fungible/create.rs
@@ -1,0 +1,119 @@
+// RGB20 Library: high-level API to RGB fungible assets.
+// Written in 2019-2022 by
+//     Dr. Maxim Orlovsky <orlovsky@lnp-bp.org>
+//
+// To the extent possible under law, the author(s) have dedicated all copyright
+// and related and neighboring rights to this software to the public domain
+// worldwide. This software is distributed without any warranty.
+//
+// You should have received a copy of the MIT License along with this software.
+// If not, see <https://opensource.org/licenses/MIT>.
+
+use std::collections::BTreeMap;
+
+use bitcoin::OutPoint;
+use chrono::Utc;
+use lnpbp::chain::Chain;
+// use rgb_core::{field, type_map};
+use stens::AsciiString;
+
+use crate::fungible::allocation::{
+    AllocationMap, IntoSealValueMap, OutpointValueMap, OutpointValueVec,
+};
+use crate::schema;
+use crate::schema::{FieldType, OwnedRightType};
+use crate::{
+    data, prelude::*, secp256k1zkp, value, Assignment, Consignment, Contract, Genesis,
+    TypedAssignments,
+};
+
+/// Extension trait for consignments defining RGB20-specific API.
+pub trait Rgb20<'consignment>: Consignment<'consignment> {
+    /// Performs primary asset issue, producing [`Contract`] consignment.
+    #[allow(clippy::too_many_arguments)]
+    fn create_rgb20(
+        chain: Chain,
+        ticker: AsciiString,
+        name: AsciiString,
+        precision: u8,
+        allocations: OutpointValueVec,
+        inflation: OutpointValueMap,
+        renomination: Option<OutPoint>,
+        epoch: Option<OutPoint>,
+    ) -> Contract;
+}
+
+impl<'consignment> Rgb20<'consignment> for Contract {
+    fn create_rgb20(
+        chain: Chain,
+        ticker: AsciiString,
+        name: AsciiString,
+        precision: u8,
+        allocations: OutpointValueVec,
+        inflation: OutpointValueMap,
+        renomination: Option<OutPoint>,
+        epoch: Option<OutPoint>,
+    ) -> Contract {
+        let now = Utc::now().timestamp();
+        let mut metadata = type_map! {
+            FieldType::Ticker => field!(AsciiString, ticker),
+            FieldType::Name => field!(AsciiString, name),
+            FieldType::Precision => field!(U8, precision),
+            FieldType::Timestamp => field!(I64, now)
+        };
+
+        let issued_supply = allocations.sum();
+        let mut owned_rights = BTreeMap::new();
+        owned_rights.insert(
+            OwnedRightType::Assets.into(),
+            TypedAssignments::zero_balanced(
+                vec![value::Revealed {
+                    value: issued_supply,
+                    blinding: secp256k1zkp::key::ONE_KEY.into(),
+                }],
+                allocations.into_seal_value_map(),
+                empty![],
+            ),
+        );
+        metadata.insert(FieldType::IssuedSupply.into(), field!(U64, issued_supply));
+
+        if !inflation.is_empty() {
+            owned_rights.insert(
+                OwnedRightType::Inflation.into(),
+                inflation.into_assignments(),
+            );
+        }
+
+        if let Some(outpoint) = renomination {
+            owned_rights.insert(
+                OwnedRightType::Renomination.into(),
+                TypedAssignments::Void(vec![Assignment::Revealed {
+                    seal: outpoint.into(),
+                    state: data::Void(),
+                }]),
+            );
+        }
+
+        if let Some(outpoint) = epoch {
+            owned_rights.insert(
+                OwnedRightType::BurnReplace.into(),
+                TypedAssignments::Void(vec![Assignment::Revealed {
+                    seal: outpoint.into(),
+                    state: data::Void(),
+                }]),
+            );
+        }
+
+        let schema = schema::schema();
+
+        let genesis = Genesis::with(
+            schema.schema_id(),
+            chain,
+            metadata.into(),
+            owned_rights,
+            bset![],
+        );
+
+        Contract::with(schema, None, genesis, empty!(), empty!(), empty!())
+    }
+}

--- a/src/fungible/create.rs
+++ b/src/fungible/create.rs
@@ -14,7 +14,6 @@ use std::collections::BTreeMap;
 use bitcoin::OutPoint;
 use chrono::Utc;
 use lnpbp::chain::Chain;
-// use rgb_core::{field, type_map};
 use stens::AsciiString;
 
 use crate::fungible::allocation::{

--- a/src/fungible/mod.rs
+++ b/src/fungible/mod.rs
@@ -11,3 +11,6 @@
 
 pub mod amount;
 pub mod allocation;
+pub mod asset;
+pub mod schema;
+pub mod create;

--- a/src/fungible/mod.rs
+++ b/src/fungible/mod.rs
@@ -9,8 +9,22 @@
 // You should have received a copy of the MIT License along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
+//! RGB20 library for working with fungible asset types, operating under
+//! schemata, defined with LNPBP-20 standard:
+//! - Root RGB20 schema, returned by [`schema::schema()`] with id
+//!   [`SCHEMA_ID_BECH32`]
+//! - RGB20 subschema, returned by [`schema::subschema()`], prohibiting asset
+//!   replacement procedure and having id [`SUBSCHEMA_ID_BECH32`]
+//! - High-level RGB20 API performing asset issuance, transfers and other
+//!   asset-management operations
+
 pub mod amount;
 pub mod allocation;
 pub mod asset;
 pub mod schema;
 pub mod create;
+pub mod transitions;
+
+pub use asset::{Asset, Error};
+pub use create::Rgb20;
+pub use schema::{schema, subschema, SCHEMA_ID_BECH32, SUBSCHEMA_ID_BECH32};

--- a/src/fungible/schema.rs
+++ b/src/fungible/schema.rs
@@ -1,0 +1,519 @@
+// RGB20 Library: high-level API to RGB fungible assets.
+// Written in 2019-2022 by
+//     Dr. Maxim Orlovsky <orlovsky@lnp-bp.org>
+//
+// To the extent possible under law, the author(s) have dedicated all copyright
+// and related and neighboring rights to this software to the public domain
+// worldwide. This software is distributed without any warranty.
+//
+// You should have received a copy of the MIT License along with this software.
+// If not, see <https://opensource.org/licenses/MIT>.
+
+//! RGB20 schemata defining fungible asset smart contract prototypes.
+
+use std::str::FromStr;
+
+use stens::{PrimitiveType, StructField, TypeRef, TypeSystem};
+
+use crate::prelude::*;
+use crate::schema::{
+    DiscreteFiniteFieldFormat, GenesisSchema, Occurrences, Schema, SchemaId, StateSchema,
+    TransitionSchema,
+};
+use crate::script::OverrideRules;
+use crate::vm::embedded::constants::*;
+use crate::ValidationScript;
+
+/// Schema identifier for full RGB20 fungible asset
+pub const SCHEMA_ID_BECH32: &str =
+    "rgbsh1kqth3x9xa5qde0vve0avfe40s28xzsjqds3dg0crv353uhmaawzs9n6k8y";
+
+/// Schema identifier for full RGB20 fungible asset subschema prohibiting burn &
+/// replace operations
+pub const SUBSCHEMA_ID_BECH32: &str =
+    "rgbsh190z9zepf8rmla9kqc0qsptchunxjmv3xkg2hnjf2v7v093z3nc9q55d54x";
+
+/// Field types for RGB20 schemata
+///
+/// Subset of known RGB schema pre-defined types applicable to fungible assets.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display)]
+#[display(Debug)]
+#[repr(u16)]
+pub enum FieldType {
+    /// Asset ticker
+    ///
+    /// Used within context of genesis or renomination state transition
+    Ticker = FIELD_TYPE_TICKER,
+
+    /// Asset name
+    ///
+    /// Used within context of genesis or renomination state transition
+    Name = FIELD_TYPE_NAME,
+
+    /// Decimal precision
+    Precision = FIELD_TYPE_PRECISION,
+
+    /// Supply issued with the genesis, secondary issuance or burn & replace
+    /// state transition
+    IssuedSupply = FIELD_TYPE_ISSUED_SUPPLY,
+
+    /// Supply burned with the burn or burn & replace state transition
+    BurnedSupply = FIELD_TYPE_BURN_SUPPLY,
+
+    /// Timestamp for genesis
+    Timestamp = FIELD_TYPE_TIMESTAMP,
+
+    /// UTXO containing the burned asset
+    BurnUtxo = FIELD_TYPE_BURN_UTXO,
+
+    /// Proofs of the burned supply
+    HistoryProof = FIELD_TYPE_HISTORY_PROOF,
+
+    /// Media format for the information proving burned supply
+    HistoryProofFormat = FIELD_TYPE_HISTORY_PROOF_FORMAT,
+}
+
+impl From<FieldType> for crate::schema::FieldType {
+    #[inline]
+    fn from(ft: FieldType) -> Self {
+        ft as crate::schema::FieldType
+    }
+}
+
+/// Owned right types used by RGB20 schemata
+///
+/// Subset of known RGB schema pre-defined types applicable to fungible assets.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display)]
+#[display(Debug)]
+#[repr(u16)]
+pub enum OwnedRightType {
+    /// Inflation control right (secondary issuance right)
+    Inflation = STATE_TYPE_INFLATION_RIGHT,
+
+    /// Asset ownership right
+    Assets = STATE_TYPE_OWNERSHIP_RIGHT,
+
+    /// Right to open a new burn & replace epoch
+    OpenEpoch = STATE_TYPE_ISSUE_EPOCH_RIGHT,
+
+    /// Right to perform burn or burn & replace operation
+    BurnReplace = STATE_TYPE_ISSUE_REPLACEMENT_RIGHT,
+
+    /// Right to perform asset renomination
+    Renomination = STATE_TYPE_RENOMINATION_RIGHT,
+}
+
+impl From<OwnedRightType> for crate::schema::OwnedRightType {
+    #[inline]
+    fn from(t: OwnedRightType) -> Self {
+        t as crate::schema::OwnedRightType
+    }
+}
+
+/// State transition types defined by RGB20 schemata
+///
+/// Subset of known RGB schema pre-defined types applicable to fungible assets.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display)]
+#[display(Debug)]
+#[repr(u16)]
+pub enum TransitionType {
+    /// Secondary issuance
+    Issue = TRANSITION_TYPE_ISSUE_FUNGIBLE,
+
+    /// Asset transfer
+    Transfer = TRANSITION_TYPE_VALUE_TRANSFER,
+
+    /// Opening of the new burn & replace asset epoch
+    Epoch = TRANSITION_TYPE_ISSUE_EPOCH,
+
+    /// Asset burn operation
+    Burn = TRANSITION_TYPE_ISSUE_BURN,
+
+    /// Burning and replacement (re-issuance) of the asset
+    BurnAndReplace = TRANSITION_TYPE_ISSUE_REPLACE,
+
+    /// Renomination (change in the asset name, ticker, contract text of
+    /// decimal precision).
+    Renomination = TRANSITION_TYPE_RENOMINATION,
+
+    /// Operation splitting rights assigned to the same UTXO
+    RightsSplit = TRANSITION_TYPE_RIGHTS_SPLIT,
+}
+
+impl From<TransitionType> for crate::schema::TransitionType {
+    #[inline]
+    fn from(t: TransitionType) -> Self {
+        t as crate::schema::TransitionType
+    }
+}
+
+fn type_system() -> TypeSystem {
+    type_system! {
+        "OutPoint" :: {
+            StructField::with("Txid"),
+            StructField::primitive(PrimitiveType::U16),
+        },
+        "Txid" :: { StructField::array(PrimitiveType::U8, 32) }
+    }
+}
+
+fn genesis() -> GenesisSchema {
+    GenesisSchema {
+        metadata: type_map! {
+            FieldType::Ticker => Once,
+            FieldType::Name => Once,
+            FieldType::Precision => Once,
+            FieldType::Timestamp => Once,
+            // We need this field in order to be able to verify pedersen
+            // commitments
+            FieldType::IssuedSupply => Once
+        },
+        owned_rights: type_map! {
+            OwnedRightType::Inflation => NoneOrMore,
+            OwnedRightType::OpenEpoch => NoneOrOnce,
+            OwnedRightType::Assets => NoneOrMore,
+            OwnedRightType::Renomination => NoneOrOnce
+        },
+        public_rights: none!(),
+    }
+}
+
+fn issue() -> TransitionSchema {
+    use Occurrences::*;
+
+    TransitionSchema {
+        metadata: type_map! {
+            // We need this field in order to be able to verify pedersen
+            // commitments
+            FieldType::IssuedSupply => Once
+        },
+        closes: type_map! {
+            OwnedRightType::Inflation => OnceOrMore
+        },
+        owned_rights: type_map! {
+            OwnedRightType::Inflation => NoneOrMore,
+            OwnedRightType::OpenEpoch => NoneOrOnce,
+            OwnedRightType::Assets => NoneOrMore
+        },
+        public_rights: none!(),
+    }
+}
+
+fn burn() -> TransitionSchema {
+    use Occurrences::*;
+
+    TransitionSchema {
+        metadata: type_map! {
+            FieldType::BurnedSupply => Once,
+            // Normally issuer should aggregate burned assets into a
+            // single UTXO; however if burn happens as a result of
+            // mistake this will be impossible, so we allow to have
+            // multiple burned UTXOs as a part of a single operation
+            FieldType::BurnUtxo => OnceOrMore,
+            FieldType::HistoryProofFormat => Once,
+            FieldType::HistoryProof => NoneOrMore
+        },
+        closes: type_map! {
+            OwnedRightType::BurnReplace => Once
+        },
+        owned_rights: type_map! {
+            OwnedRightType::BurnReplace => NoneOrOnce
+        },
+        public_rights: none!(),
+    }
+}
+
+fn renomination() -> TransitionSchema {
+    use Occurrences::*;
+
+    TransitionSchema {
+        metadata: type_map! {
+            FieldType::Ticker => NoneOrOnce,
+            FieldType::Name => NoneOrOnce,
+            FieldType::Precision => NoneOrOnce
+        },
+        closes: type_map! {
+            OwnedRightType::Renomination => Once
+        },
+        owned_rights: type_map! {
+            OwnedRightType::Renomination => NoneOrOnce
+        },
+        public_rights: none!(),
+    }
+}
+
+/// Builds & returns complete RGB20 schema (root schema object)
+pub fn schema() -> Schema {
+    use Occurrences::*;
+
+    Schema {
+        rgb_features: none!(),
+        root_id: none!(),
+        genesis: genesis(),
+        type_system: type_system(),
+        extensions: none!(),
+        transitions: type_map! {
+            TransitionType::Issue => issue(),
+            TransitionType::Transfer => TransitionSchema {
+                metadata: none!(),
+                closes: type_map! {
+                    OwnedRightType::Assets => OnceOrMore
+                },
+                owned_rights: type_map! {
+                    OwnedRightType::Assets => NoneOrMore
+                },
+                public_rights: none!()
+            },
+            TransitionType::Epoch => TransitionSchema {
+                metadata: none!(),
+                closes: type_map! {
+                    OwnedRightType::OpenEpoch => Once
+                },
+                owned_rights: type_map! {
+                    OwnedRightType::OpenEpoch => NoneOrOnce,
+                    OwnedRightType::BurnReplace => NoneOrOnce
+                },
+                public_rights: none!()
+            },
+            TransitionType::Burn => burn(),
+            TransitionType::BurnAndReplace => TransitionSchema {
+                metadata: type_map! {
+                    FieldType::BurnedSupply => Once,
+                    // Normally issuer should aggregate burned assets into a
+                    // single UTXO; however if burn happens as a result of
+                    // mistake this will be impossible, so we allow to have
+                    // multiple burned UTXOs as a part of a single operation
+                    FieldType::BurnUtxo => OnceOrMore,
+                    // We need this field in order to be able to verify pedersen
+                    // commitments
+                    FieldType::IssuedSupply => Once,
+                    FieldType::HistoryProofFormat => Once,
+                    FieldType::HistoryProof => NoneOrMore
+                },
+                closes: type_map! {
+                    OwnedRightType::BurnReplace => Once
+                },
+                owned_rights: type_map! {
+                    OwnedRightType::BurnReplace => NoneOrOnce,
+                    OwnedRightType::Assets => OnceOrMore
+                },
+                public_rights: none!()
+            },
+            TransitionType::Renomination => renomination(),
+            // Allows split of rights if they were occasionally allocated to the
+            // same UTXO, for instance both assets and issuance right. Without
+            // this type of transition either assets or inflation rights will be
+            // lost.
+            TransitionType::RightsSplit => TransitionSchema {
+                metadata: type_map! {},
+                closes: type_map! {
+                    OwnedRightType::Inflation => NoneOrMore,
+                    OwnedRightType::Assets => NoneOrMore,
+                    OwnedRightType::OpenEpoch => NoneOrOnce,
+                    OwnedRightType::BurnReplace => NoneOrMore,
+                    OwnedRightType::Renomination => NoneOrOnce
+                },
+                owned_rights: type_map! {
+                    OwnedRightType::Inflation => NoneOrMore,
+                    OwnedRightType::Assets => NoneOrMore,
+                    OwnedRightType::OpenEpoch => NoneOrOnce,
+                    OwnedRightType::BurnReplace => NoneOrMore,
+                    OwnedRightType::Renomination => NoneOrOnce
+                },
+                public_rights: none!()
+            }
+        },
+        field_types: type_map! {
+            // Rational: if we will use just 26 letters of English alphabet (and
+            // we are not limited by them), we will have 26^8 possible tickers,
+            // i.e. > 208 trillions, which is sufficient amount
+            FieldType::Ticker => TypeRef::ascii_string(),
+            FieldType::Name => TypeRef::ascii_string(),
+            // Contract text may contain URL, text or text representation of
+            // Ricardian contract, up to 64kb. If the contract doesn't fit, a
+            // double SHA256 hash and URL should be used instead, pointing to
+            // the full contract text, where hash must be represented by a
+            // hexadecimal string, optionally followed by `\n` and text URL
+            FieldType::Precision => TypeRef::u8(),
+            // We need this b/c allocated amounts are hidden behind Pedersen
+            // commitments
+            FieldType::IssuedSupply => TypeRef::u64(),
+            // Supply in either burn or burn-and-replace procedure
+            FieldType::BurnedSupply => TypeRef::u64(),
+            // While UNIX timestamps allow negative numbers; in context of RGB
+            // Schema, assets can't be issued in the past before RGB or Bitcoin
+            // even existed; so we prohibit all the dates before RGB release
+            // This timestamp is equal to 10/10/2020 @ 2:37pm (UTC)
+            FieldType::Timestamp => TypeRef::i64(),
+            FieldType::HistoryProof => TypeRef::bytes(),
+            FieldType::BurnUtxo => TypeRef::new("OutPoint")
+        },
+        owned_right_types: type_map! {
+            // How much issuer can issue tokens on this path. If there is no
+            // limit, than `core::u64::MAX` / sum(inflation_assignments)
+            // must be used, as this will be a de-facto limit to the
+            // issuance
+            OwnedRightType::Inflation => StateSchema::DiscreteFiniteField(DiscreteFiniteFieldFormat::Unsigned64bit),
+            OwnedRightType::Assets => StateSchema::DiscreteFiniteField(DiscreteFiniteFieldFormat::Unsigned64bit),
+            OwnedRightType::OpenEpoch => StateSchema::Declarative,
+            OwnedRightType::BurnReplace => StateSchema::Declarative,
+            OwnedRightType::Renomination => StateSchema::DataContainer
+        },
+        public_right_types: none!(),
+        script: ValidationScript::Embedded,
+        override_rules: OverrideRules::AllowAnyVm,
+    }
+}
+
+/// Provides the only defined RGB20 subschema, which prohibits replace procedure
+/// and allows only burn operations
+pub fn subschema() -> Schema {
+    use Occurrences::*;
+
+    Schema {
+        rgb_features: none!(),
+        root_id: SchemaId::from_str(SCHEMA_ID_BECH32)
+            .expect("Broken root schema ID for RGB20 sub-schema"),
+        type_system: type_system(),
+        genesis: genesis(),
+        extensions: none!(),
+        transitions: type_map! {
+            TransitionType::Issue => issue(),
+            TransitionType::Transfer => TransitionSchema {
+                metadata: none!(),
+                closes: type_map! {
+                    OwnedRightType::Assets => OnceOrMore
+                },
+                owned_rights: type_map! {
+                    OwnedRightType::Assets => NoneOrMore
+                },
+                public_rights: none!()
+            },
+            TransitionType::Epoch => TransitionSchema {
+                metadata: none!(),
+                closes: type_map! {
+                    OwnedRightType::OpenEpoch => Once
+                },
+                owned_rights: type_map! {
+                    OwnedRightType::BurnReplace => NoneOrOnce
+                },
+                public_rights: none!()
+            },
+            TransitionType::Burn => burn(),
+            TransitionType::Renomination => renomination(),
+            // Allows split of rights if they were occasionally allocated to the
+            // same UTXO, for instance both assets and issuance right. Without
+            // this type of transition either assets or inflation rights will be
+            // lost.
+            TransitionType::RightsSplit => TransitionSchema {
+                metadata: type_map! {},
+                closes: type_map! {
+                    OwnedRightType::Inflation => NoneOrMore,
+                    OwnedRightType::Assets => NoneOrMore,
+                    OwnedRightType::BurnReplace => NoneOrMore,
+                    OwnedRightType::Renomination => NoneOrOnce
+                },
+                owned_rights: type_map! {
+                    OwnedRightType::Inflation => NoneOrMore,
+                    OwnedRightType::Assets => NoneOrMore,
+                    OwnedRightType::BurnReplace => NoneOrMore,
+                    OwnedRightType::Renomination => NoneOrOnce
+                },
+                public_rights: none!()
+            }
+        },
+        field_types: type_map! {
+            // Rational: if we will use just 26 letters of English alphabet (and
+            // we are not limited by them), we will have 26^8 possible tickers,
+            // i.e. > 208 trillions, which is sufficient amount
+            FieldType::Ticker => TypeRef::ascii_string(),
+            FieldType::Name => TypeRef::ascii_string(),
+            FieldType::Precision => TypeRef::u8(),
+            // We need this b/c allocated amounts are hidden behind Pedersen
+            // commitments
+            FieldType::IssuedSupply => TypeRef::u64(),
+            // Supply in either burn or burn-and-replace procedure
+            FieldType::BurnedSupply => TypeRef::u64(),
+            // While UNIX timestamps allow negative numbers; in context of RGB
+            // Schema, assets can't be issued in the past before RGB or Bitcoin
+            // even existed; so we prohibit all the dates before RGB release
+            // This timestamp is equal to 10/10/2020 @ 2:37pm (UTC)
+            FieldType::Timestamp => TypeRef::i64(),
+            FieldType::BurnUtxo => TypeRef::new("OutPoint")
+        },
+        owned_right_types: type_map! {
+            // How much issuer can issue tokens on this path. If there is no
+            // limit, than `core::u64::MAX` / sum(inflation_assignments)
+            // must be used, as this will be a de-facto limit to the
+            // issuance
+            OwnedRightType::Inflation => StateSchema::DiscreteFiniteField(DiscreteFiniteFieldFormat::Unsigned64bit),
+            OwnedRightType::Assets => StateSchema::DiscreteFiniteField(DiscreteFiniteFieldFormat::Unsigned64bit),
+            OwnedRightType::OpenEpoch => StateSchema::Declarative,
+            OwnedRightType::BurnReplace => StateSchema::Declarative,
+            OwnedRightType::Renomination => StateSchema::DataContainer
+        },
+        public_right_types: none!(),
+        script: ValidationScript::Embedded,
+        override_rules: OverrideRules::AllowAnyVm,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::schema::SchemaVerify;
+    use crate::Validity;
+
+    use lnpbp::bech32::Bech32ZipString;
+    use strict_encoding::{StrictDecode, StrictEncode};
+
+    use super::*;
+
+    #[test]
+    fn schema_id() {
+        let id = schema().schema_id();
+        assert_eq!(id.to_string(), SCHEMA_ID_BECH32);
+        assert_eq!(
+            id.to_string(),
+            "rgbsh1kqth3x9xa5qde0vve0avfe40s28xzsjqds3dg0crv353uhmaawzs9n6k8y"
+        );
+    }
+
+    #[test]
+    fn subschema_id() {
+        let id = subschema().schema_id();
+        assert_eq!(id.to_string(), SUBSCHEMA_ID_BECH32);
+        assert_eq!(
+            id.to_string(),
+            "rgbsh190z9zepf8rmla9kqc0qsptchunxjmv3xkg2hnjf2v7v093z3nc9q55d54x"
+        );
+    }
+
+    #[test]
+    fn schema_strict_encode() {
+        let data = schema()
+            .strict_serialize()
+            .expect("RGB-20 schema serialization failed");
+
+        let bech32data = data.bech32_zip_string();
+        println!("{}", bech32data);
+
+        let schema20 =
+            Schema::strict_deserialize(data).expect("RGB-20 schema deserialization failed");
+
+        assert_eq!(schema(), schema20);
+        assert_eq!(format!("{:#?}", schema()), format!("{:#?}", schema20));
+        assert_eq!(
+            bech32data,
+            "z1qxz4zvgwcgcqe0px485p33q8lqgsc0yp559jc3tzus5jjmxd62t07ytvyu5592552sumk0klh9x4qhq2p58t\
+            0mncd5hemq42vpct4dm8ypn3tmz78gdcdmd8vtgfcx768dr6q3ux3yjrltuemfg9xjfms200vqrcjm2kpuludpq\
+            j86ykrneqdpxspv899cd4zxxgugtsvs0tq438y640thu5tszeentnvgxyrt6wagk7fxaefus4vl0znmtxq9rxz2\
+            r4n980un4fwx9mt7myuy6tr22lu23t7xqpec06d9uvjjeutlc3waut80n"
+        );
+    }
+
+    #[test]
+    fn subschema_verify() {
+        let status = subschema().schema_verify(&schema());
+        assert_eq!(status.validity(), Validity::Valid);
+    }
+}

--- a/src/fungible/transitions.rs
+++ b/src/fungible/transitions.rs
@@ -1,0 +1,162 @@
+// RGB20 Library: high-level API to RGB fungible assets.
+// Written in 2019-2022 by
+//     Dr. Maxim Orlovsky <orlovsky@lnp-bp.org>
+//
+// To the extent possible under law, the author(s) have dedicated all copyright
+// and related and neighboring rights to this software to the public domain
+// worldwide. This software is distributed without any warranty.
+//
+// You should have received a copy of the MIT License along with this software.
+// If not, see <https://opensource.org/licenses/MIT>.
+
+use std::collections::BTreeSet;
+
+use bitcoin::OutPoint;
+use bp::seals::txout::ExplicitSeal;
+
+use crate::fungible::{
+    allocation::{AllocationMap, AllocationValueMap, AllocationValueVec},
+    schema::{OwnedRightType, TransitionType},
+    Asset,
+};
+use crate::prelude::*;
+
+/// Errors happening during construction of RGB-20 asset state transitions
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display, Error)]
+#[display(doc_comments)]
+pub enum Error {
+    /// input {0} is not related to the contract
+    UnrelatedInput(OutPoint),
+
+    /// sum of inputs and outputs is not equal
+    InputsNotEqualOutputs,
+
+    /// issue allowance {allowed} for the provided set of issue-controlling
+    /// rights is insufficient to issue the requested amount {requested}
+    InsufficientIssueAllowance {
+        /// Allowed issue value
+        allowed: AtomicValue,
+        /// Requested issue value
+        requested: AtomicValue,
+    },
+
+    /// the requested supply {requested} does not match the total supply
+    /// {assigned} allocated to the owned rights consumed by the operation
+    SupplyMismatch {
+        /// Assigned supply change rights
+        assigned: AtomicValue,
+        /// Requested supply change
+        requested: AtomicValue,
+    },
+
+    /// method was provided with a set of seals for owned rights which are not
+    /// a part of the asset data: {0:?}
+    UnknownSeals(BTreeSet<OutPoint>),
+}
+
+impl Asset {
+    /// Performs secondary issue closing an inflation-controlling seal over
+    /// inflation state transition, which is constructed and returned by this
+    /// function
+    pub fn inflate(
+        &self,
+        _closing: BTreeSet<OutPoint>,
+        _next_inflation: AllocationValueMap,
+        _allocations: AllocationValueVec,
+    ) -> Result<Transition, Error> {
+        todo!()
+    }
+
+    /// Opens a new epoch by closing epoch-controlling seal over epoch opening
+    /// state transition, which is constructed and returned by this function
+    pub fn epoch(
+        &self,
+        _closing: OutPoint,
+        _next_epoch: Option<ExplicitSeal>,
+        _burning_seal: Option<ExplicitSeal>,
+    ) -> Result<Transition, Error> {
+        todo!()
+    }
+
+    /// Burns certain amount of the asset by closing burn-controlling seal over
+    /// proof-of-burn state transition, which is constructed and returned by
+    /// this function
+    pub fn burn(
+        &self,
+        _closing: OutPoint,
+        _burned_value: AtomicValue,
+        _burned_utxos: BTreeSet<OutPoint>,
+        _next_burn: Option<ExplicitSeal>,
+    ) -> Result<Transition, Error> {
+        todo!()
+    }
+
+    /// Burns and re-allocates certain amount of the asset by closing
+    /// burn-controlling seal over proof-of-burn state transition, which is
+    /// constructed and returned by this function
+    pub fn burn_replace(
+        &self,
+        _closing: OutPoint,
+        _burned_value: AtomicValue,
+        _burned_utxos: BTreeSet<OutPoint>,
+        _next_burn: Option<ExplicitSeal>,
+        _allocations: AllocationValueVec,
+    ) -> Result<Transition, Error> {
+        todo!()
+    }
+
+    /// Creates a fungible asset-specific state transition (i.e. RGB-20
+    /// schema-based) given an asset information, inputs and desired outputs
+    pub fn transfer(
+        &self,
+        inputs: BTreeSet<OutPoint>,
+        payment: EndpointValueMap,
+        change: SealValueMap,
+    ) -> Result<Transition, Error> {
+        // Collecting all input allocations
+        let mut input_usto = Vec::<OwnedValue>::new();
+        for outpoint in inputs {
+            let coins = self.outpoint_coins(outpoint);
+            if coins.is_empty() {
+                Err(Error::UnrelatedInput(outpoint))?
+            }
+            input_usto.extend(coins);
+        }
+        // Computing sum of inputs
+        let input_amounts: Vec<_> = input_usto.iter().map(|coin| coin.state).collect();
+        let total_inputs = input_amounts
+            .iter()
+            .fold(0u64, |acc, coin| acc + coin.value);
+        let total_outputs = change.sum() + payment.sum();
+
+        if total_inputs != total_outputs {
+            Err(Error::InputsNotEqualOutputs)?
+        }
+
+        let assignments = type_map! {
+            OwnedRightType::Assets =>
+            TypedAssignments::zero_balanced(input_amounts, change, payment)
+        };
+
+        let mut parent = ParentOwnedRights::default();
+        for coin in input_usto {
+            parent
+                .entry(coin.outpoint.node_id)
+                .or_insert_with(|| empty!())
+                .entry(OwnedRightType::Assets.into())
+                .or_insert_with(|| empty!())
+                .push(coin.outpoint.no);
+        }
+
+        let transition = Transition::with(
+            TransitionType::Transfer,
+            empty!(),
+            empty!(),
+            assignments.into(),
+            empty!(),
+            parent,
+        );
+
+        Ok(transition)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ extern crate serde_crate as serde;
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde_with;
+#[macro_use]
+extern crate stens;
 
 mod consignments;
 mod disclosure;
@@ -26,6 +28,7 @@ pub mod fungible;
 mod state;
 pub mod psbt;
 pub mod blank;
+pub mod util;
 
 pub mod prelude {
     pub use rgb_core::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,18 @@
 // You should have received a copy of the MIT License along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
+#![recursion_limit = "256"]
+// Coding conventions
+#![deny(
+    non_upper_case_globals,
+    non_camel_case_types,
+    non_snake_case,
+    unused_mut,
+    unused_imports,
+    dead_code,
+    missing_docs
+)]
+
 #[macro_use]
 extern crate amplify;
 #[macro_use]

--- a/src/state.rs
+++ b/src/state.rs
@@ -103,7 +103,8 @@ impl StateAtom {
 #[derive(StrictEncode, StrictDecode)]
 #[display("{state}@{seal}")]
 pub struct AssignedState<State>
-where State: StateTrait
+where
+    State: StateTrait,
 {
     pub outpoint: NodeOutpoint,
     pub seal: OutPoint,
@@ -111,7 +112,8 @@ where State: StateTrait
 }
 
 impl<State> AssignedState<State>
-where State: StateTrait
+where
+    State: StateTrait,
 {
     pub fn with(
         seal: seal::Revealed,
@@ -199,7 +201,7 @@ impl ContractState {
             if owned_value.seal == outpoint {
                 state.insert(OutpointState {
                     node_outpoint: owned_value.outpoint,
-                    state: owned_value.state.clone().into(),
+                    state: owned_value.state.into(),
                 });
             }
         }
@@ -239,7 +241,7 @@ impl ContractState {
                 .or_default()
                 .insert(OutpointState {
                     node_outpoint: owned_value.outpoint,
-                    state: owned_value.state.clone().into(),
+                    state: owned_value.state.into(),
                 });
         }
         for owned_data in &self.owned_data {
@@ -283,7 +285,7 @@ impl ContractState {
                     .or_default()
                     .insert(OutpointState {
                         node_outpoint: owned_value.outpoint,
-                        state: owned_value.state.clone().into(),
+                        state: owned_value.state.into(),
                     });
             }
         }
@@ -316,7 +318,9 @@ impl ContractState {
         self.add_node(txid, transition);
     }
 
-    pub fn add_extension(&mut self, extension: &Extension) { self.add_node(zero!(), extension); }
+    pub fn add_extension(&mut self, extension: &Extension) {
+        self.add_node(zero!(), extension);
+    }
 
     fn add_node(&mut self, txid: Txid, node: &impl Node) {
         let node_id = node.node_id();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,12 @@
+pub fn ticker_validator(name: &str) -> Result<(), String> {
+    if name.len() < 3 || name.len() > 8 || name.chars().any(|c| c < 'A' && c > 'Z') {
+        Err(
+            "Ticker name must be between 3 and 8 chars, contain no spaces and \
+            consist only of capital letters\
+            "
+            .to_string(),
+        )
+    } else {
+        Ok(())
+    }
+}


### PR DESCRIPTION
So, watching you build RGB is like watching Leonardo Da Vinci paint the Mona Lisa. And I feel like this, opening this malformed PR:
![Botched Ecce Homo](https://user-images.githubusercontent.com/285690/179060396-e2b3754c-33a9-4edc-8765-9f272169eb8b.jpeg)

I was merely inspired by your original deprecated comment (before Wednesday's call), but alas, it's beyond my skill, and not terribly necessary, either.

That said, if you think there's some value in the work, I'm having trouble with resolving some of the `cargo check` errors.

If you want me to finish it, I could use a few pointers, and I can also squash the commits into a proper commit message.