### PR TITLE
Handle chain information in explicit form in invoices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
 [[package]]
 name = "bp-primitives"
 version = "0.10.7"
-source = "git+https://github.com/BP-WG/bp-core?branch=primitives#b0c8538c223c29e85ad58fe4f6be59d6c8555515"
+source = "git+https://github.com/BP-WG/bp-core?branch=primitives#a24e6ffca3fce442706f2cab59613d8d66dc7c20"
 dependencies = [
  "amplify",
  "commit_verify",

--- a/invoice/src/builder.rs
+++ b/invoice/src/builder.rs
@@ -32,15 +32,16 @@ pub struct RgbInvoiceBuilder(RgbInvoice);
 
 impl RgbInvoiceBuilder {
     pub fn new(beneficiary: impl Into<Beneficiary>) -> Self {
+        let beneficiary = beneficiary.into();
         Self(RgbInvoice {
             transports: vec![RgbTransport::UnspecifiedMeans],
             contract: None,
             iface: None,
             operation: None,
             assignment: None,
-            beneficiary: beneficiary.into(),
+            chain: beneficiary.chain_info().unwrap_or(Chain::Bitcoin),
+            beneficiary,
             owned_state: TypedState::Void,
-            chain: None,
             expiry: None,
             unknown_query: none!(),
         })
@@ -126,7 +127,7 @@ impl RgbInvoiceBuilder {
                     chain2 != Chain::Regtest => {}
             _ => return Err(self),
         }
-        self.0.chain = Some(chain);
+        self.0.chain = chain;
         Ok(self)
     }
 

--- a/invoice/src/builder.rs
+++ b/invoice/src/builder.rs
@@ -114,9 +114,20 @@ impl RgbInvoiceBuilder {
         self.set_amount(coins as u64, cents as u64, precision)
     }
 
-    pub fn set_chain(mut self, chain: impl Into<Chain>) -> Self {
-        self.0.chain = Some(chain.into());
-        self
+    pub fn set_chain(mut self, chain: impl Into<Chain>) -> Result<Self, Self> {
+        let chain = chain.into();
+        match (self.0.beneficiary.chain_info(), chain) {
+            (None, _) => {}
+            (Some(chain1), chain2) if chain1 == chain2 => {}
+            (Some(chain1), chain2)
+                if chain1.is_testnet() &&
+                    chain2.is_testnet() &&
+                    chain1 != Chain::Regtest &&
+                    chain2 != Chain::Regtest => {}
+            _ => return Err(self),
+        }
+        self.0.chain = Some(chain);
+        Ok(self)
     }
 
     pub fn set_expiry_timestamp(mut self, expiry: i64) -> Self {

--- a/invoice/src/invoice.rs
+++ b/invoice/src/invoice.rs
@@ -86,7 +86,7 @@ pub struct RgbInvoice {
     pub assignment: Option<FieldName>,
     pub beneficiary: Beneficiary,
     pub owned_state: TypedState,
-    pub chain: Option<Chain>,
+    pub chain: Chain,
     /// UTC unix timestamp
     pub expiry: Option<i64>,
     pub unknown_query: IndexMap<String, String>,

--- a/invoice/src/invoice.rs
+++ b/invoice/src/invoice.rs
@@ -19,7 +19,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bp::Address;
+use bp::{Address, AddressNetwork};
 use indexmap::IndexMap;
 use rgb::interface::TypedState;
 use rgb::{AttachId, Chain, ContractId, SecretSeal};
@@ -53,6 +53,28 @@ pub enum Beneficiary {
     BlindedSeal(SecretSeal),
     #[from]
     WitnessUtxo(Address),
+}
+
+impl Beneficiary {
+    pub fn chain_info(&self) -> Option<Chain> {
+        match self {
+            Beneficiary::BlindedSeal(_) => None,
+            Beneficiary::WitnessUtxo(Address {
+                network: AddressNetwork::Mainnet,
+                ..
+            }) => Some(Chain::Bitcoin),
+            Beneficiary::WitnessUtxo(Address {
+                network: AddressNetwork::Regtest,
+                ..
+            }) => Some(Chain::Regtest),
+            Beneficiary::WitnessUtxo(Address {
+                network: AddressNetwork::Testnet,
+                ..
+            }) => Some(Chain::Testnet3),
+        }
+    }
+
+    pub fn has_chain_info(&self) -> bool { self.chain_info().is_some() }
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]

--- a/invoice/src/parse.rs
+++ b/invoice/src/parse.rs
@@ -64,53 +64,45 @@ pub enum TransportParseError {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Display, Error, From)]
-#[display(inner)]
+#[display(doc_comments)]
 #[non_exhaustive]
 pub enum InvoiceParseError {
     #[from]
+    #[display(inner)]
     Uri(fluent_uri::ParseError),
 
-    #[display(doc_comments)]
     /// invalid invoice.
     Invalid,
 
-    #[display(doc_comments)]
     /// invalid invoice scheme {0}.
     InvalidScheme(String),
 
-    #[display(doc_comments)]
     /// no invoice transport has been provided.
     NoTransport,
 
-    #[display(doc_comments)]
     /// invalid invoice: contract ID present but no contract interface provided.
     ContractIdNoIface,
 
-    #[display(doc_comments)]
     /// invalid contract ID.
     InvalidContractId(String),
 
-    #[display(doc_comments)]
     /// invalid interface {0}.
     InvalidIface(String),
 
-    #[display(doc_comments)]
     /// invalid expiration timestamp {0}.
     InvalidExpiration(String),
 
-    #[display(doc_comments)]
     /// invalid query parameter {0}.
     InvalidQueryParam(String),
 
     #[from]
+    #[display(inner)]
     Id(baid58::Baid58ParseError),
 
-    #[display(doc_comments)]
     /// can't recognize beneficiary "": it should be either a bitcoin address or
     /// a blinded UTXO seal.
     Beneficiary(String),
 
-    #[display(doc_comments)]
     /// network {0:?} is not supported.
     UnsupportedNetwork(AddressNetwork),
 
@@ -118,7 +110,6 @@ pub enum InvoiceParseError {
     Num(ParseIntError),
 
     #[from]
-    #[display(doc_comments)]
     /// invalid interface name.
     IfaceName(InvalidIdent),
 }

--- a/invoice/src/parse.rs
+++ b/invoice/src/parse.rs
@@ -23,13 +23,13 @@ use std::fmt::{self, Debug, Display, Formatter};
 use std::num::ParseIntError;
 use std::str::FromStr;
 
-use bp::{Address, AddressNetwork};
+use bp::{Address, AddressNetwork, Chain, ChainParseError};
 use fluent_uri::enc::EStr;
 use fluent_uri::Uri;
 use indexmap::IndexMap;
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use rgb::interface::TypedState;
-use rgb::{Chain, ContractId, SecretSeal};
+use rgb::{ContractId, SecretSeal};
 use strict_encoding::{InvalidIdent, TypeName};
 
 use super::{Beneficiary, RgbInvoice, RgbTransport};
@@ -37,6 +37,7 @@ use super::{Beneficiary, RgbInvoice, RgbTransport};
 const OMITTED: char = '~';
 const EXPIRY: &str = "expiry";
 const ENDPOINTS: &str = "endpoints";
+const CHAIN: &str = "chain";
 const TRANSPORT_SEP: char = ',';
 const TRANSPORT_HOST_SEP: &str = "://";
 const QUERY_ENCODE: &AsciiSet = &CONTROLS
@@ -106,7 +107,16 @@ pub enum InvoiceParseError {
     /// network {0:?} is not supported.
     UnsupportedNetwork(AddressNetwork),
 
+    /// chain `{chain}` explicitly specified in the invoice doesn't match
+    /// network `{addr_chain}` used in the provided beneficiary address.
+    ChainMismatch { chain: Chain, addr_chain: Chain },
+
     #[from]
+    #[display(inner)]
+    InvalidChain(ChainParseError),
+
+    #[from]
+    #[display(inner)]
     Num(ParseIntError),
 
     #[from]
@@ -115,14 +125,32 @@ pub enum InvoiceParseError {
 }
 
 impl RgbInvoice {
+    #[inline]
+    fn non_default_chain(&self) -> Option<Chain> {
+        if self.beneficiary.has_chain_info() {
+            return None;
+        }
+        if let Some(chain) = self.chain {
+            if chain != Chain::Bitcoin {
+                return Some(chain);
+            }
+        }
+        None
+    }
+
+    #[inline]
     fn has_params(&self) -> bool {
         self.expiry.is_some() ||
             self.transports != vec![RgbTransport::UnspecifiedMeans] ||
+            self.non_default_chain().is_some() ||
             !self.unknown_query.is_empty()
     }
 
     fn query_params(&self) -> IndexMap<String, String> {
         let mut query_params: IndexMap<String, String> = IndexMap::new();
+        if let Some(chain) = self.non_default_chain() {
+            query_params.insert(CHAIN.to_string(), chain.to_string());
+        }
         if let Some(expiry) = self.expiry {
             query_params.insert(EXPIRY.to_string(), expiry.to_string());
         }
@@ -305,6 +333,26 @@ impl FromStr for RgbInvoice {
             };
 
         let mut query_params = map_query_params(&uri)?;
+
+        let chain = if let Some(chain_str) = query_params.remove(CHAIN) {
+            match (Chain::from_str(&chain_str)?, chain) {
+                (chain, None) => Some(chain),
+                (chain, Some(addr_chain)) if chain == addr_chain => Some(chain),
+                (chain, Some(addr_chain))
+                    if chain.is_testnet() &&
+                        addr_chain.is_testnet() &&
+                        chain != Chain::Regtest &&
+                        addr_chain != Chain::Regtest =>
+                {
+                    Some(chain)
+                }
+                (chain, Some(addr_chain)) => {
+                    return Err(InvoiceParseError::ChainMismatch { chain, addr_chain });
+                }
+            }
+        } else {
+            None
+        };
 
         let transports = if let Some(endpoints) = query_params.remove(ENDPOINTS) {
             let tokens: Vec<&str> = endpoints.split(TRANSPORT_SEP).collect();

--- a/invoice/src/parse.rs
+++ b/invoice/src/parse.rs
@@ -127,15 +127,11 @@ pub enum InvoiceParseError {
 impl RgbInvoice {
     #[inline]
     fn non_default_chain(&self) -> Option<Chain> {
-        if self.beneficiary.has_chain_info() {
-            return None;
+        if self.chain == Chain::Bitcoin {
+            None
+        } else {
+            Some(self.chain)
         }
-        if let Some(chain) = self.chain {
-            if chain != Chain::Bitcoin {
-                return Some(chain);
-            }
-        }
-        None
     }
 
     #[inline]
@@ -384,7 +380,7 @@ impl FromStr for RgbInvoice {
             assignment: None,
             beneficiary,
             owned_state: value,
-            chain,
+            chain: chain.unwrap_or(Chain::Bitcoin),
             expiry,
             unknown_query: query_params,
         })
@@ -483,7 +479,10 @@ mod test {
             .set_chain(Chain::Testnet3)
             .unwrap()
             .finish();
-        assert_eq!(invoice.to_string(), "rgb:~/RGB20/mxVFsFW5N4mu1HPkxPttorvocvzeZ7KZyk");
+        assert_eq!(
+            invoice.to_string(),
+            "rgb:~/RGB20/mxVFsFW5N4mu1HPkxPttorvocvzeZ7KZyk?chain=testnet"
+        );
 
         // address-based regtest - mismatching
         assert!(
@@ -499,44 +498,44 @@ mod test {
             "rgb:~/RGB20/utxob:egXsFnw-5Eud7WKYn-7DVQvcPbc-rR69YmgmG-veacwmUFo-uMFKFb",
         )
         .unwrap();
-        assert_eq!(invoice.chain, None);
+        assert_eq!(invoice.chain, Chain::Bitcoin);
 
         let invoice = RgbInvoice::from_str(
             "rgb:~/RGB20/utxob:egXsFnw-5Eud7WKYn-7DVQvcPbc-rR69YmgmG-veacwmUFo-uMFKFb?\
              chain=testnet",
         )
         .unwrap();
-        assert_eq!(invoice.chain, Some(Chain::Testnet3));
+        assert_eq!(invoice.chain, Chain::Testnet3);
 
         let invoice = RgbInvoice::from_str(
             "rgb:~/RGB20/utxob:egXsFnw-5Eud7WKYn-7DVQvcPbc-rR69YmgmG-veacwmUFo-uMFKFb?\
              chain=testnet3",
         )
         .unwrap();
-        assert_eq!(invoice.chain, Some(Chain::Testnet3));
+        assert_eq!(invoice.chain, Chain::Testnet3);
 
         let invoice = RgbInvoice::from_str(
             "rgb:~/RGB20/utxob:egXsFnw-5Eud7WKYn-7DVQvcPbc-rR69YmgmG-veacwmUFo-uMFKFb?chain=signet",
         )
         .unwrap();
-        assert_eq!(invoice.chain, Some(Chain::Signet));
+        assert_eq!(invoice.chain, Chain::Signet);
 
         let invoice = RgbInvoice::from_str(
             "rgb:~/RGB20/utxob:egXsFnw-5Eud7WKYn-7DVQvcPbc-rR69YmgmG-veacwmUFo-uMFKFb?\
              chain=regtest",
         )
         .unwrap();
-        assert_eq!(invoice.chain, Some(Chain::Regtest));
+        assert_eq!(invoice.chain, Chain::Regtest);
 
         let invoice =
             RgbInvoice::from_str("rgb:~/RGB20/bc1qpws79r3ea4yy2ujsahwrmy2gutdj8w5whnhket").unwrap();
-        assert_eq!(invoice.chain, None);
+        assert_eq!(invoice.chain, Chain::Bitcoin);
 
         let invoice = RgbInvoice::from_str(
             "rgb:~/RGB20/bc1qpws79r3ea4yy2ujsahwrmy2gutdj8w5whnhket?chain=bitcoin",
         )
         .unwrap();
-        assert_eq!(invoice.chain, Some(Chain::Bitcoin));
+        assert_eq!(invoice.chain, Chain::Bitcoin);
 
         assert_eq!(
             RgbInvoice::from_str(
@@ -551,12 +550,12 @@ mod test {
         let invoice =
             RgbInvoice::from_str("rgb:~/RGB20/mxVFsFW5N4mu1HPkxPttorvocvzeZ7KZyk?chain=testnet")
                 .unwrap();
-        assert_eq!(invoice.chain, Some(Chain::Testnet3));
+        assert_eq!(invoice.chain, Chain::Testnet3);
 
         let invoice =
             RgbInvoice::from_str("rgb:~/RGB20/mxVFsFW5N4mu1HPkxPttorvocvzeZ7KZyk?chain=signet")
                 .unwrap();
-        assert_eq!(invoice.chain, Some(Chain::Signet));
+        assert_eq!(invoice.chain, Chain::Signet);
 
         assert_eq!(
             RgbInvoice::from_str("rgb:~/RGB20/mxVFsFW5N4mu1HPkxPttorvocvzeZ7KZyk?chain=regtest",),

--- a/invoice/src/parse.rs
+++ b/invoice/src/parse.rs
@@ -52,6 +52,7 @@ const QUERY_ENCODE: &AsciiSet = &CONTROLS
 
 #[derive(Clone, PartialEq, Eq, Debug, Display, Error, From)]
 #[display(inner)]
+#[non_exhaustive]
 pub enum TransportParseError {
     #[display(doc_comments)]
     /// invalid transport {0}.
@@ -64,6 +65,7 @@ pub enum TransportParseError {
 
 #[derive(Clone, PartialEq, Eq, Debug, Display, Error, From)]
 #[display(inner)]
+#[non_exhaustive]
 pub enum InvoiceParseError {
     #[from]
     Uri(fluent_uri::ParseError),


### PR DESCRIPTION
This is a breaking change since inside the invoice structure we make `chain` non-optional; plus we add new error cases and make `set_chain` return `Result`. Thus I am making this PR against `v11` branch.

Closes #103