### PR TITLE
Fix blank transition builder

### DIFF
--- a/std/src/interface/rgb21.rs
+++ b/std/src/interface/rgb21.rs
@@ -101,6 +101,9 @@ impl Allocation {
     pub fn with(index: TokenIndex, fraction: OwnedFraction) -> Allocation {
         Allocation(index, fraction)
     }
+
+    pub fn token_id(self) -> TokenIndex { self.0 }
+    pub fn fraction(self) -> OwnedFraction { self.1 }
 }
 
 impl StrictSerialize for Allocation {}

--- a/std/src/persistence/hoard.rs
+++ b/std/src/persistence/hoard.rs
@@ -35,7 +35,9 @@ use strict_encoding::TypeName;
 
 use crate::accessors::{MergeReveal, MergeRevealError};
 use crate::containers::{Cert, Consignment, ContentId, ContentSigs};
-use crate::interface::{rgb20, ContractSuppl, Iface, IfaceId, IfacePair, SchemaIfaces};
+use crate::interface::{
+    rgb20, rgb21, rgb25, ContractSuppl, Iface, IfaceId, IfacePair, SchemaIfaces,
+};
 use crate::persistence::{InventoryError, Stash, StashError, StashInconsistency};
 use crate::LIB_NAME_RGB_STD;
 
@@ -78,10 +80,16 @@ impl Hoard {
     pub fn preset() -> Self {
         let rgb20 = rgb20();
         let rgb20_id = rgb20.iface_id();
+        let rgb21 = rgb21();
+        let rgb21_id = rgb21.iface_id();
+        let rgb25 = rgb25();
+        let rgb25_id = rgb25.iface_id();
         Hoard {
             schemata: none!(),
             ifaces: tiny_bmap! {
                 rgb20_id => rgb20,
+                rgb21_id => rgb21,
+                rgb25_id => rgb25,
             },
             geneses: none!(),
             suppl: none!(),

--- a/std/src/persistence/inventory.rs
+++ b/std/src/persistence/inventory.rs
@@ -410,13 +410,29 @@ pub trait Inventory: Deref<Target = Self::Stash> {
         let schema_ifaces = self.contract_schema(contract_id)?;
         let iface = self.iface_by_name(&iface.into())?;
         let schema = &schema_ifaces.schema;
-        let iimpl = schema_ifaces
-            .iimpls
-            .get(&iface.iface_id())
-            .ok_or(DataError::NoIfaceImpl(schema.schema_id(), iface.iface_id()))?;
-        let builder =
+
+        if schema_ifaces.iimpls.is_empty() {
+            return Err(InventoryError::DataError(DataError::NoIfaceImpl(
+                schema.schema_id(),
+                iface.iface_id(),
+            )));
+        }
+
+        let builder = if let Some(iimpl) = schema_ifaces.iimpls.get(&iface.iface_id()) {
             TransitionBuilder::blank_transition(iface.clone(), schema.clone(), iimpl.clone())
-                .expect("internal inconsistency");
+                .expect("internal inconsistency")
+        } else {
+            let (default_iface_id, default_iimpl) = schema_ifaces.iimpls.first_key_value().unwrap();
+            let default_iface = self.iface_by_id(*default_iface_id)?;
+
+            TransitionBuilder::blank_transition(
+                default_iface.clone(),
+                schema.clone(),
+                default_iimpl.clone(),
+            )
+            .expect("internal inconsistency")
+        };
+
         Ok(builder)
     }
 

--- a/std/src/stl/specs.rs
+++ b/std/src/stl/specs.rs
@@ -477,8 +477,9 @@ impl DivisibleAssetSpec {
     pub fn details(&self) -> Option<&str> { self.naming.details.as_ref().map(|d| d.as_str()) }
 }
 
-#[derive(Clone, Eq, PartialEq, Debug, Default)]
-#[derive(StrictType, StrictEncode, StrictDecode)]
+#[derive(Wrapper, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, From, Debug)]
+#[wrapper(Deref, Display)]
+#[derive(StrictDumb, StrictType, StrictEncode, StrictDecode)]
 #[strict_type(lib = LIB_NAME_RGB_CONTRACT)]
 #[cfg_attr(
     feature = "serde",
@@ -495,6 +496,13 @@ impl FromStr for RicardianContract {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = Confined::try_from_iter(s.chars())?;
         Ok(Self(s))
+    }
+}
+
+impl RicardianContract {
+    pub fn from_strict_val_unchecked(value: &StrictVal) -> Self {
+        let s = value.unwrap_string();
+        RicardianContract::from_str(&s).expect("invalid term data")
     }
 }
 


### PR DESCRIPTION
**Description**

This PR intent fix a blank transition builder when contract has another `ifaceimpl`. This particular case occurs when issuer issues many contracts with different `ifaceimpl `in the same UTXO.

CC @cryptoquick @dr-orlovsky 

