### PR TITLE
ifaces: use correct fungible builder type

### DIFF
--- a/src/interface/builder.rs
+++ b/src/interface/builder.rs
@@ -357,10 +357,10 @@ pub struct OperationBuilder<Seal: ExposedSeal> {
     asset_tags: TinyOrdMap<AssignmentType, AssetTag>,
 
     global: GlobalState,
-    // rights: TinyOrdMap<AssignmentType, Confined<HashSet<BuilderSeal<Seal>>, 1, U8>>,
+    // rights: TinyOrdMap<AssignmentType, Confined<HashSet<BuilderSeal<Seal>>, 1, U16>>,
     fungible:
-        TinyOrdMap<AssignmentType, Confined<HashMap<BuilderSeal<Seal>, RevealedValue>, 1, U8>>,
-    data: TinyOrdMap<AssignmentType, Confined<HashMap<BuilderSeal<Seal>, RevealedData>, 1, U8>>,
+        TinyOrdMap<AssignmentType, Confined<HashMap<BuilderSeal<Seal>, RevealedValue>, 1, U16>>,
+    data: TinyOrdMap<AssignmentType, Confined<HashMap<BuilderSeal<Seal>, RevealedData>, 1, U16>>,
     // TODO: add attachments
     // TODO: add valencies
 }


### PR DESCRIPTION
Since `Terminal.seals` is a `SmallXxx` collection, so the seal quantity may reach up to 65535, then the corresponding builder should allow seal quantity up to 65535.

```rust
pub struct Terminal {
    pub seals: SmallOrdSet<TerminalSeal>,
    pub tx: Option<Tx>,
}
```

It's not a protocol change, if you wish I can port this fix to `v0.10` branch.