### PR TITLE
Fix bundle merge reveal check

### DIFF
--- a/src/accessors/bundle.rs
+++ b/src/accessors/bundle.rs
@@ -62,7 +62,7 @@ impl BundleExt for TransitionBundle {
             return Ok(false);
         }
         self.known_transitions
-            .insert(opid, transition.clone())
+            .insert(opid, transition)
             .expect("same size as input map");
         Ok(true)
     }

--- a/src/accessors/merge_reveal.rs
+++ b/src/accessors/merge_reveal.rs
@@ -42,8 +42,8 @@ pub enum MergeRevealError {
     #[display(inner)]
     AnchorMismatch(MergeError),
 
-    /// the merged bundles contain excessive transactions.
-    ExcessiveTransactions,
+    /// the merged bundles contain excessive transitions.
+    ExcessiveTransitions,
 
     /// contract id provided for the merge-reveal operation doesn't matches
     /// multi-protocol commitment.
@@ -187,12 +187,14 @@ impl<Seal: ExposedSeal> MergeReveal for Assignments<Seal> {
 impl MergeReveal for TransitionBundle {
     fn merge_reveal(mut self, other: Self) -> Result<Self, MergeRevealError> {
         debug_assert_eq!(self.commitment_id(), other.commitment_id());
-        if self.known_transitions.len() + other.known_transitions.len() > self.input_map.len() ||
-            self.known_transitions
-                .extend(other.known_transitions)
-                .is_err()
+
+        if self
+            .known_transitions
+            .extend(other.known_transitions)
+            .is_err() ||
+            self.input_map.len() < self.known_transitions.len()
         {
-            return Err(MergeRevealError::ExcessiveTransactions);
+            return Err(MergeRevealError::ExcessiveTransitions);
         }
         Ok(self)
     }

--- a/src/persistence/hoard.rs
+++ b/src/persistence/hoard.rs
@@ -190,7 +190,7 @@ impl Hoard {
 
         // Update asset tags
         self.asset_tags
-            .insert(contract_id, consignment.asset_tags.clone())?;
+            .insert(contract_id, consignment.asset_tags)?;
 
         Ok(())
     }


### PR DESCRIPTION
**Description**

This PR intent fix the merge reveal bundle check. Also, adjusts the error message for correct naming.
