### PR TITLE
Cross-chain secret seals. New network/chain in invoices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "bp-consensus"
 version = "0.11.0-beta.3"
-source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#cbc896d075772a7b4eb620cd8c76cae86ff331c1"
+source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#1d7b50834dc40d84b093ede000de9ad38a9e0996"
 dependencies = [
  "amplify",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 [[package]]
 name = "bp-core"
 version = "0.11.0-beta.2"
-source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#cbc896d075772a7b4eb620cd8c76cae86ff331c1"
+source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#1d7b50834dc40d84b093ede000de9ad38a9e0996"
 dependencies = [
  "amplify",
  "bp-consensus",
@@ -248,7 +248,7 @@ dependencies = [
 [[package]]
 name = "bp-dbc"
 version = "0.11.0-beta.2"
-source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#cbc896d075772a7b4eb620cd8c76cae86ff331c1"
+source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#1d7b50834dc40d84b093ede000de9ad38a9e0996"
 dependencies = [
  "amplify",
  "base85",
@@ -274,7 +274,7 @@ dependencies = [
 [[package]]
 name = "bp-seals"
 version = "0.11.0-beta.2"
-source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#cbc896d075772a7b4eb620cd8c76cae86ff331c1"
+source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#1d7b50834dc40d84b093ede000de9ad38a9e0996"
 dependencies = [
  "amplify",
  "baid58",
@@ -649,7 +649,7 @@ dependencies = [
 [[package]]
 name = "rgb-core"
 version = "0.11.0-beta.3"
-source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#50cd4191f2b92a86e8d79b1a2d15aa94bd50c367"
+source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#d598eee90dfa21ef9a34a8376342cffa43dbd4e9"
 dependencies = [
  "aluvm",
  "amplify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,8 @@ dependencies = [
 [[package]]
 name = "bp-consensus"
 version = "0.11.0-beta.3"
-source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#1d7b50834dc40d84b093ede000de9ad38a9e0996"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190ac89a2a3c79d5bfb677f48e5393691832c540973341831572edaffdce0881"
 dependencies = [
  "amplify",
  "chrono",
@@ -231,8 +232,9 @@ dependencies = [
 
 [[package]]
 name = "bp-core"
-version = "0.11.0-beta.2"
-source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#1d7b50834dc40d84b093ede000de9ad38a9e0996"
+version = "0.11.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69269d27e32d784e37f7ca7cdf964fe5e30c5bff1ca2e229a118c84c8efdd179"
 dependencies = [
  "amplify",
  "bp-consensus",
@@ -247,8 +249,9 @@ dependencies = [
 
 [[package]]
 name = "bp-dbc"
-version = "0.11.0-beta.2"
-source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#1d7b50834dc40d84b093ede000de9ad38a9e0996"
+version = "0.11.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cef9a98c7ae4f1bb333ad8e55c9d8a91f071c347d35b62e19959faa07572b11"
 dependencies = [
  "amplify",
  "base85",
@@ -273,8 +276,9 @@ dependencies = [
 
 [[package]]
 name = "bp-seals"
-version = "0.11.0-beta.2"
-source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#1d7b50834dc40d84b093ede000de9ad38a9e0996"
+version = "0.11.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211bb77e320abf4bba6c272fc85d73e5203140ca39e299271f4714d8b6029fe"
 dependencies = [
  "amplify",
  "baid58",
@@ -331,7 +335,8 @@ dependencies = [
 [[package]]
 name = "commit_encoding_derive"
 version = "0.10.0"
-source = "git+https://github.com/LNP-BP/client_side_validation?branch=v0.11#2d3a0a2981409c493067edfc94338088884b1aa7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00033f14d67c4169d588f085ea2faeb7b610cf03a74d42ea09eeba31abef2047"
 dependencies = [
  "amplify",
  "amplify_syn",
@@ -342,8 +347,9 @@ dependencies = [
 
 [[package]]
 name = "commit_verify"
-version = "0.11.0-beta.2"
-source = "git+https://github.com/LNP-BP/client_side_validation?branch=v0.11#2d3a0a2981409c493067edfc94338088884b1aa7"
+version = "0.11.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e001679b9be6a5df24facdae179e6ba1cffb503c875d691eac024db8d0f8d1"
 dependencies = [
  "amplify",
  "commit_encoding_derive",
@@ -649,7 +655,7 @@ dependencies = [
 [[package]]
 name = "rgb-core"
 version = "0.11.0-beta.3"
-source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#d598eee90dfa21ef9a34a8376342cffa43dbd4e9"
+source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#744560f68518b19eab7ae8135571910282e72e58"
 dependencies = [
  "aluvm",
  "amplify",
@@ -873,17 +879,18 @@ dependencies = [
 
 [[package]]
 name = "single_use_seals"
-version = "0.11.0-beta.2"
+version = "0.11.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30647a1342641c45ca7c1dcd5ae7db16533b86744e827c84cfed875db2de3fe"
+checksum = "1b14ebe6be1e12070208a6f2ceb49f946d835b1f7dfb809a4db025de8f5ffe0a"
 dependencies = [
  "amplify_derive",
 ]
 
 [[package]]
 name = "strict_encoding"
-version = "2.6.1"
-source = "git+https://github.com/strict-types/strict-encoding?branch=phantom#2123237a512bbe28e8e419e7d4f899dfedfa758c"
+version = "2.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa76decc8ac190a56ba7857c023b69ed52b781ed974c5a181eac62cdbfc99521"
 dependencies = [
  "amplify",
  "half",
@@ -894,7 +901,8 @@ dependencies = [
 [[package]]
 name = "strict_encoding_derive"
 version = "2.0.1"
-source = "git+https://github.com/strict-types/strict-encoding?branch=phantom#2123237a512bbe28e8e419e7d4f899dfedfa758c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37064ec285e2a633465eb525c8698eea51373dee889fe310e0d32df8343e7f4f"
 dependencies = [
  "amplify_syn",
  "heck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,8 +654,9 @@ dependencies = [
 
 [[package]]
 name = "rgb-core"
-version = "0.11.0-beta.3"
-source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#744560f68518b19eab7ae8135571910282e72e58"
+version = "0.11.0-beta.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb0581f9bc33b509400aa9225d2308dfd45af413a4fe38f7c4b823a7e09e6036"
 dependencies = [
  "aluvm",
  "amplify",
@@ -674,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "rgb-invoice"
-version = "0.11.0-beta.3"
+version = "0.11.0-beta.4"
 dependencies = [
  "amplify",
  "baid58",
@@ -691,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "rgb-std"
-version = "0.11.0-beta.3"
+version = "0.11.0-beta.4"
 dependencies = [
  "amplify",
  "baid58",
@@ -713,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "rgb-stl"
-version = "0.11.0-beta.3"
+version = "0.11.0-beta.4"
 dependencies = [
  "rgb-std",
  "strict_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,20 +218,7 @@ dependencies = [
 [[package]]
 name = "bp-consensus"
 version = "0.11.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190ac89a2a3c79d5bfb677f48e5393691832c540973341831572edaffdce0881"
-dependencies = [
- "amplify",
- "chrono",
- "commit_verify",
- "secp256k1 0.28.0",
- "strict_encoding",
-]
-
-[[package]]
-name = "bp-consensus"
-version = "0.11.0-beta.3"
-source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#50630d40828c522f78066c6ca473f0f3291b977d"
+source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#cbc896d075772a7b4eb620cd8c76cae86ff331c1"
 dependencies = [
  "amplify",
  "chrono",
@@ -245,10 +232,10 @@ dependencies = [
 [[package]]
 name = "bp-core"
 version = "0.11.0-beta.2"
-source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#50630d40828c522f78066c6ca473f0f3291b977d"
+source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#cbc896d075772a7b4eb620cd8c76cae86ff331c1"
 dependencies = [
  "amplify",
- "bp-consensus 0.11.0-beta.3 (git+https://github.com/BP-WG/bp-core?branch=v0.11)",
+ "bp-consensus",
  "bp-dbc",
  "bp-seals",
  "commit_verify",
@@ -261,11 +248,11 @@ dependencies = [
 [[package]]
 name = "bp-dbc"
 version = "0.11.0-beta.2"
-source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#50630d40828c522f78066c6ca473f0f3291b977d"
+source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#cbc896d075772a7b4eb620cd8c76cae86ff331c1"
 dependencies = [
  "amplify",
  "base85",
- "bp-consensus 0.11.0-beta.3 (git+https://github.com/BP-WG/bp-core?branch=v0.11)",
+ "bp-consensus",
  "commit_verify",
  "secp256k1 0.28.0",
  "serde",
@@ -281,17 +268,17 @@ dependencies = [
  "amplify",
  "bech32",
  "bitcoin_hashes",
- "bp-consensus 0.11.0-beta.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bp-consensus",
 ]
 
 [[package]]
 name = "bp-seals"
 version = "0.11.0-beta.2"
-source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#50630d40828c522f78066c6ca473f0f3291b977d"
+source = "git+https://github.com/BP-WG/bp-core?branch=v0.11#cbc896d075772a7b4eb620cd8c76cae86ff331c1"
 dependencies = [
  "amplify",
  "baid58",
- "bp-consensus 0.11.0-beta.3 (git+https://github.com/BP-WG/bp-core?branch=v0.11)",
+ "bp-consensus",
  "bp-dbc",
  "commit_verify",
  "rand",
@@ -344,8 +331,7 @@ dependencies = [
 [[package]]
 name = "commit_encoding_derive"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00033f14d67c4169d588f085ea2faeb7b610cf03a74d42ea09eeba31abef2047"
+source = "git+https://github.com/LNP-BP/client_side_validation?branch=v0.11#2d3a0a2981409c493067edfc94338088884b1aa7"
 dependencies = [
  "amplify",
  "amplify_syn",
@@ -357,8 +343,7 @@ dependencies = [
 [[package]]
 name = "commit_verify"
 version = "0.11.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5598661b1d90b149f0b944faef8c1d1d131f847678a6c450b9540b629ac11291"
+source = "git+https://github.com/LNP-BP/client_side_validation?branch=v0.11#2d3a0a2981409c493067edfc94338088884b1aa7"
 dependencies = [
  "amplify",
  "commit_encoding_derive",
@@ -560,9 +545,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "mime"
@@ -664,7 +649,7 @@ dependencies = [
 [[package]]
 name = "rgb-core"
 version = "0.11.0-beta.3"
-source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#7eb443b87745d2a05030f556d8a33ba8dbed0f0a"
+source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#50cd4191f2b92a86e8d79b1a2d15aa94bd50c367"
 dependencies = [
  "aluvm",
  "amplify",
@@ -898,8 +883,7 @@ dependencies = [
 [[package]]
 name = "strict_encoding"
 version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7b75b4af0aff9dd97b68df262bf0e807b7d007cc860fa217943f898a05a5ab"
+source = "git+https://github.com/strict-types/strict-encoding?branch=phantom#2123237a512bbe28e8e419e7d4f899dfedfa758c"
 dependencies = [
  "amplify",
  "half",
@@ -910,8 +894,7 @@ dependencies = [
 [[package]]
 name = "strict_encoding_derive"
 version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37064ec285e2a633465eb525c8698eea51373dee889fe310e0d32df8343e7f4f"
+source = "git+https://github.com/strict-types/strict-encoding?branch=phantom#2123237a512bbe28e8e419e7d4f899dfedfa758c"
 dependencies = [
  "amplify_syn",
  "heck",
@@ -1224,9 +1207,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.30"
+version = "0.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
+checksum = "97a4882e6b134d6c28953a387571f1acdd3496830d5e36c5e3a1075580ea641c"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,10 +93,4 @@ wasm-bindgen-test = "0.3"
 features = [ "all" ]
 
 [patch.crates-io]
-strict_encoding = { git = "https://github.com/strict-types/strict-encoding", branch = "phantom" }
-commit_verify = { git = "https://github.com/LNP-BP/client_side_validation", branch = "v0.11" }
-bp-consensus = { git = "https://github.com/BP-WG/bp-core", branch = "v0.11" }
-bp-dbc = { git = "https://github.com/BP-WG/bp-core", branch = "v0.11" }
-bp-seals = { git = "https://github.com/BP-WG/bp-core", branch = "v0.11" }
-bp-core = { git = "https://github.com/BP-WG/bp-core", branch = "v0.11" }
 rgb-core = { git = "https://github.com/RGB-WG/rgb-core", branch = "v0.11" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0-beta.3"
+version = "0.11.0-beta.4"
 authors = ["Dr Maxim Orlovsky <orlovsky@lnp-bp.org>"]
 homepage = "https://github.com/RGB-WG"
 repository = "https://github.com/RGB-WG/rgb-wallet"
@@ -24,12 +24,12 @@ license = "Apache-2.0"
 [workspace.dependencies]
 amplify = "4.5.0"
 baid58 = "0.4.4"
-strict_encoding = "2.6.1"
+strict_encoding = "2.6.2"
 strict_types = "1.6.3"
-commit_verify = { version = "0.11.0-beta.2", features = ["stl"] }
-bp-core = { version = "0.11.0-beta.2", features = ["stl"] }
+commit_verify = { version = "0.11.0-beta.3", features = ["stl"] }
+bp-core = { version = "0.11.0-beta.3", features = ["stl"] }
 bp-invoice = { version = "0.11.0-beta.3" }
-rgb-core = { version = "0.11.0-beta.3", features = ["stl"] }
+rgb-core = { version = "0.11.0-beta.4", features = ["stl"] }
 indexmap = "2.0.2"
 serde_crate = { package = "serde", version = "1", features = ["derive"] }
 
@@ -58,7 +58,7 @@ strict_types = { workspace = true }
 commit_verify = { workspace = true }
 bp-core = { workspace = true }
 rgb-core = { workspace = true }
-rgb-invoice = { version = "0.11.0-beta.3", path = "invoice" }
+rgb-invoice = { version = "0.11.0-beta.4", path = "invoice" }
 baid58 = { workspace = true }
 base85 = "=2.0.0"
 chrono = "0.4.31"
@@ -91,6 +91,3 @@ wasm-bindgen-test = "0.3"
 
 [package.metadata.docs.rs]
 features = [ "all" ]
-
-[patch.crates-io]
-rgb-core = { git = "https://github.com/RGB-WG/rgb-core", branch = "v0.11" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ base85 = "=2.0.0"
 chrono = "0.4.31"
 indexmap = { workspace = true }
 serde_crate = { workspace = true, optional = true }
+rand = "0.8.5"
 
 [features]
 default = []
@@ -92,6 +93,9 @@ wasm-bindgen-test = "0.3"
 features = [ "all" ]
 
 [patch.crates-io]
+strict_encoding = { git = "https://github.com/strict-types/strict-encoding", branch = "phantom" }
+commit_verify = { git = "https://github.com/LNP-BP/client_side_validation", branch = "v0.11" }
+bp-consensus = { git = "https://github.com/BP-WG/bp-core", branch = "v0.11" }
 bp-dbc = { git = "https://github.com/BP-WG/bp-core", branch = "v0.11" }
 bp-seals = { git = "https://github.com/BP-WG/bp-core", branch = "v0.11" }
 bp-core = { git = "https://github.com/BP-WG/bp-core", branch = "v0.11" }

--- a/invoice/src/builder.rs
+++ b/invoice/src/builder.rs
@@ -21,17 +21,17 @@
 
 use std::str::FromStr;
 
-use invoice::Network;
 use rgb::ContractId;
 
 use super::{Beneficiary, InvoiceState, Precision, RgbInvoice, RgbTransport, TransportParseError};
+use crate::invoice::XChainNet;
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct RgbInvoiceBuilder(RgbInvoice);
 
 #[allow(clippy::result_large_err)]
 impl RgbInvoiceBuilder {
-    pub fn new(beneficiary: impl Into<Beneficiary>) -> Self {
+    pub fn new(beneficiary: impl Into<XChainNet<Beneficiary>>) -> Self {
         Self(RgbInvoice {
             transports: vec![RgbTransport::UnspecifiedMeans],
             contract: None,
@@ -40,21 +40,20 @@ impl RgbInvoiceBuilder {
             assignment: None,
             beneficiary: beneficiary.into(),
             owned_state: InvoiceState::Void,
-            network: None,
             expiry: None,
             unknown_query: none!(),
         })
     }
 
-    pub fn with(contract_id: ContractId, beneficiary: impl Into<Beneficiary>) -> Self {
+    pub fn with(contract_id: ContractId, beneficiary: impl Into<XChainNet<Beneficiary>>) -> Self {
         Self::new(beneficiary).set_contract(contract_id)
     }
 
-    pub fn rgb20(contract_id: ContractId, beneficiary: impl Into<Beneficiary>) -> Self {
+    pub fn rgb20(contract_id: ContractId, beneficiary: impl Into<XChainNet<Beneficiary>>) -> Self {
         Self::with(contract_id, beneficiary).set_interface("RGB20")
     }
 
-    pub fn rgb20_anything(beneficiary: impl Into<Beneficiary>) -> Self {
+    pub fn rgb20_anything(beneficiary: impl Into<XChainNet<Beneficiary>>) -> Self {
         Self::new(beneficiary).set_interface("RGB20")
     }
 
@@ -117,11 +116,6 @@ impl RgbInvoiceBuilder {
         let coins = amount.floor();
         let cents = amount - coins;
         self.set_amount(coins as u64, cents as u64, precision)
-    }
-
-    pub fn set_network(mut self, network: impl Into<Network>) -> Self {
-        self.0.network = Some(network.into());
-        self
     }
 
     pub fn set_expiry_timestamp(mut self, expiry: i64) -> Self {

--- a/invoice/src/builder.rs
+++ b/invoice/src/builder.rs
@@ -22,6 +22,7 @@
 use std::str::FromStr;
 
 use rgb::ContractId;
+use strict_encoding::{FieldName, TypeName};
 
 use super::{Beneficiary, InvoiceState, Precision, RgbInvoice, RgbTransport, TransportParseError};
 use crate::invoice::XChainNet;
@@ -62,18 +63,18 @@ impl RgbInvoiceBuilder {
         self
     }
 
-    pub fn set_interface(mut self, name: &'static str) -> Self {
-        self.0.iface = Some(tn!(name));
+    pub fn set_interface(mut self, name: impl Into<TypeName>) -> Self {
+        self.0.iface = Some(name.into());
         self
     }
 
-    pub fn set_operation(mut self, name: &'static str) -> Self {
-        self.0.operation = Some(tn!(name));
+    pub fn set_operation(mut self, name: impl Into<TypeName>) -> Self {
+        self.0.operation = Some(name.into());
         self
     }
 
-    pub fn set_assignment(mut self, name: &'static str) -> Self {
-        self.0.assignment = Some(fname!(name));
+    pub fn set_assignment(mut self, name: impl Into<FieldName>) -> Self {
+        self.0.assignment = Some(name.into());
         self
     }
 

--- a/invoice/src/invoice.rs
+++ b/invoice/src/invoice.rs
@@ -20,7 +20,7 @@
 // limitations under the License.
 
 use indexmap::IndexMap;
-use invoice::{AddressNetwork, AddressPayload};
+use invoice::{AddressNetwork, AddressPayload, Network};
 use rgb::{AttachId, ContractId, Layer1, SecretSeal};
 use strict_encoding::{FieldName, TypeName};
 
@@ -116,6 +116,15 @@ impl<T> XChainNet<T> {
             ChainNet::BitcoinRegtest => XChainNet::BitcoinRegtest(data),
             ChainNet::LiquidMainnet => XChainNet::LiquidMainnet(data),
             ChainNet::LiquidTestnet => XChainNet::LiquidTestnet(data),
+        }
+    }
+
+    pub fn bitcoin(network: Network, data: T) -> Self {
+        match network {
+            Network::Mainnet => Self::BitcoinMainnet(data),
+            Network::Testnet3 => Self::BitcoinTestnet(data),
+            Network::Signet => Self::BitcoinSignet(data),
+            Network::Regtest => Self::BitcoinRegtest(data),
         }
     }
 

--- a/invoice/src/invoice.rs
+++ b/invoice/src/invoice.rs
@@ -85,7 +85,7 @@ impl ChainNet {
         }
     }
 
-    pub(crate) fn address_network(&self) -> AddressNetwork {
+    pub fn address_network(&self) -> AddressNetwork {
         match self {
             ChainNet::BitcoinMainnet => AddressNetwork::Mainnet,
             ChainNet::BitcoinTestnet | ChainNet::BitcoinSignet => AddressNetwork::Testnet,
@@ -142,6 +142,7 @@ impl<T> XChainNet<T> {
     }
 
     pub fn layer1(&self) -> Layer1 { self.chain_network().layer1() }
+    pub fn address_network(&self) -> AddressNetwork { self.chain_network().address_network() }
     pub fn is_prod(&self) -> bool { self.chain_network().is_prod() }
 }
 
@@ -170,6 +171,7 @@ pub struct RgbInvoice {
 
 impl RgbInvoice {
     pub fn chain_network(&self) -> ChainNet { self.beneficiary.chain_network() }
+    pub fn address_network(&self) -> AddressNetwork { self.beneficiary.address_network() }
     pub fn layer1(&self) -> Layer1 { self.beneficiary.layer1() }
     pub fn is_prod(&self) -> bool { self.beneficiary.is_prod() }
 }

--- a/invoice/src/invoice.rs
+++ b/invoice/src/invoice.rs
@@ -21,7 +21,7 @@
 
 use indexmap::IndexMap;
 use invoice::{Address, Network};
-use rgb::{AttachId, ContractId, Layer1, SecretSeal};
+use rgb::{AttachId, ContractId, Layer1, SecretSeal, XChain};
 use strict_encoding::{FieldName, TypeName};
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
@@ -52,7 +52,7 @@ pub enum Beneficiary {
     //       Move Baid58 encoding from BP seals to here. Use utxob1 for bitcoin, and use
     //       utxol1 for liquid.
     #[from]
-    BlindedSeal(SecretSeal),
+    BlindedSeal(XChain<SecretSeal>),
     #[from]
     WitnessVoutBitcoin(Address),
     // TODO: Add support for Liquid beneficiaries

--- a/invoice/src/lib.rs
+++ b/invoice/src/lib.rs
@@ -39,6 +39,8 @@ pub use amount::{Amount, CoinAmount, Precision};
 pub use builder::RgbInvoiceBuilder;
 pub use parse::{InvoiceParseError, TransportParseError};
 
-pub use crate::invoice::{Beneficiary, InvoiceState, RgbInvoice, RgbTransport};
+pub use crate::invoice::{
+    Beneficiary, ChainNet, InvoiceState, RgbInvoice, RgbTransport, XChainNet,
+};
 
 pub const LIB_NAME_RGB_CONTRACT: &str = "RGBContract";

--- a/invoice/src/parse.rs
+++ b/invoice/src/parse.rs
@@ -212,7 +212,7 @@ impl Display for XChainNet<Beneficiary> {
                     .trim_start_matches("bcrt1");
                 // 26 27 34 42 62 -- 14..72
                 // TODO: Do address chunking
-                f.write_str(&s)
+                f.write_str(s)
             }
         }
     }

--- a/src/accessors/assignments.rs
+++ b/src/accessors/assignments.rs
@@ -23,20 +23,20 @@ use amplify::confinement::SmallVec;
 use commit_verify::Conceal;
 use rgb::{
     Assign, AssignAttach, AssignData, AssignFungible, AssignRights, ExposedSeal, ExposedState,
-    TypedAssigns, XSeal,
+    TypedAssigns, XChain,
 };
 
 pub trait TypedAssignsExt<Seal: ExposedSeal> {
-    fn reveal_seal(&mut self, seal: XSeal<Seal>);
+    fn reveal_seal(&mut self, seal: XChain<Seal>);
 
-    fn filter_revealed_seals(&self) -> Vec<XSeal<Seal>>;
+    fn filter_revealed_seals(&self) -> Vec<XChain<Seal>>;
 }
 
 impl<Seal: ExposedSeal> TypedAssignsExt<Seal> for TypedAssigns<Seal> {
-    fn reveal_seal(&mut self, seal: XSeal<Seal>) {
+    fn reveal_seal(&mut self, seal: XChain<Seal>) {
         fn reveal<State: ExposedState, Seal: ExposedSeal>(
             vec: &mut SmallVec<Assign<State, Seal>>,
-            revealed: XSeal<Seal>,
+            revealed: XChain<Seal>,
         ) {
             for assign in vec.iter_mut() {
                 match assign {
@@ -65,7 +65,7 @@ impl<Seal: ExposedSeal> TypedAssignsExt<Seal> for TypedAssigns<Seal> {
         }
     }
 
-    fn filter_revealed_seals(&self) -> Vec<XSeal<Seal>> {
+    fn filter_revealed_seals(&self) -> Vec<XChain<Seal>> {
         match self {
             TypedAssigns::Declarative(s) => {
                 s.iter().filter_map(AssignRights::revealed_seal).collect()

--- a/src/accessors/bundle.rs
+++ b/src/accessors/bundle.rs
@@ -19,7 +19,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rgb::{GraphSeal, OpId, Operation, Transition, TransitionBundle, XSeal};
+use rgb::{GraphSeal, OpId, Operation, Transition, TransitionBundle, XChain};
 
 use crate::accessors::TypedAssignsExt;
 
@@ -32,7 +32,7 @@ pub enum RevealError {
 
 pub trait BundleExt {
     /// Ensures that the seal is revealed inside the bundle.
-    fn reveal_seal(&mut self, seal: XSeal<GraphSeal>);
+    fn reveal_seal(&mut self, seal: XChain<GraphSeal>);
 
     /// Ensures that the transition is revealed inside the bundle.
     ///
@@ -44,7 +44,7 @@ pub trait BundleExt {
 }
 
 impl BundleExt for TransitionBundle {
-    fn reveal_seal(&mut self, seal: XSeal<GraphSeal>) {
+    fn reveal_seal(&mut self, seal: XChain<GraphSeal>) {
         for (_, transition) in self.known_transitions.keyed_values_mut() {
             for (_, assign) in transition.assignments.keyed_values_mut() {
                 assign.reveal_seal(seal)

--- a/src/containers/consignment.rs
+++ b/src/containers/consignment.rs
@@ -26,7 +26,8 @@ use amplify::confinement::{LargeVec, MediumBlob, SmallOrdMap, TinyOrdMap, TinyOr
 use rgb::validation::{self};
 use rgb::{
     AnchoredBundle, AssetTag, AssignmentType, AttachId, BundleId, ContractHistory, ContractId,
-    Extension, Genesis, GraphSeal, OpId, Operation, Schema, SchemaId, SubSchema, Transition, XSeal,
+    Extension, Genesis, GraphSeal, OpId, Operation, Schema, SchemaId, SubSchema, Transition,
+    XChain,
 };
 use strict_encoding::{StrictDeserialize, StrictDumb, StrictSerialize};
 
@@ -89,7 +90,7 @@ pub struct Consignment<const TYPE: bool> {
     pub genesis: Genesis,
 
     /// Set of seals which are history terminals.
-    pub terminals: SmallOrdMap<BundleId, Terminal>,
+    pub terminals: SmallOrdMap<BundleId, XChain<Terminal>>,
 
     /// Data on all anchored state transitions contained in the consignments.
     pub bundles: LargeVec<AnchoredBundle>,
@@ -226,7 +227,7 @@ impl<const TYPE: bool> Consignment<TYPE> {
         Ok(history)
     }
 
-    pub fn reveal_bundle_seal(&mut self, bundle_id: BundleId, revealed: XSeal<GraphSeal>) {
+    pub fn reveal_bundle_seal(&mut self, bundle_id: BundleId, revealed: XChain<GraphSeal>) {
         for anchored_bundle in &mut self.bundles {
             if anchored_bundle.bundle.bundle_id() == bundle_id {
                 anchored_bundle.bundle.reveal_seal(revealed);

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -46,4 +46,4 @@ pub use disclosure::Disclosure;
 pub use indexed::IndexedConsignment;
 pub use partials::{Batch, CloseMethodSet, Fascia, TransitionInfo};
 pub use seal::{BuilderSeal, TerminalSeal, VoutSeal};
-pub use util::{ContainerVer, Terminal, XOutpoint};
+pub use util::{ContainerVer, Terminal};

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -46,4 +46,4 @@ pub use disclosure::Disclosure;
 pub use indexed::IndexedConsignment;
 pub use partials::{Batch, CloseMethodSet, Fascia, TransitionInfo};
 pub use seal::{BuilderSeal, TerminalSeal, VoutSeal};
-pub use util::{ContainerVer, Terminal, XchainOutpoint};
+pub use util::{ContainerVer, Terminal, XOutpoint};

--- a/src/containers/partials.rs
+++ b/src/containers/partials.rs
@@ -28,7 +28,6 @@ use std::vec;
 use amplify::confinement;
 use amplify::confinement::{Confined, U24};
 use bp::seals::txout::CloseMethod;
-use bp::Outpoint;
 use commit_verify::mpc;
 use rgb::{
     ContractId, OpId, Operation, Transition, TransitionBundle, TxoSeal, XAnchor, XOutputSeal,
@@ -154,11 +153,7 @@ impl TransitionInfo {
         seals: impl AsRef<[XOutputSeal]>,
     ) -> Result<Self, confinement::Error> {
         let inputs = Confined::<Vec<_>, 1, U24>::try_from_iter(
-            seals
-                .as_ref()
-                .iter()
-                .copied()
-                .map(|seal| seal.map(Outpoint::from)),
+            seals.as_ref().iter().copied().map(XOutpoint::from),
         )?;
         let methods = seals
             .as_ref()

--- a/src/containers/partials.rs
+++ b/src/containers/partials.rs
@@ -30,11 +30,11 @@ use amplify::confinement::{Confined, U24};
 use bp::seals::txout::CloseMethod;
 use commit_verify::mpc;
 use rgb::{
-    ContractId, OpId, Operation, Transition, TransitionBundle, TxoSeal, XAnchor, XOutputSeal,
+    ContractId, OpId, Operation, Transition, TransitionBundle, TxoSeal, XAnchor, XOutpoint,
+    XOutputSeal,
 };
 use strict_encoding::{StrictDeserialize, StrictDumb, StrictSerialize};
 
-use crate::containers::XOutpoint;
 use crate::LIB_NAME_RGB_STD;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]

--- a/src/containers/seal.rs
+++ b/src/containers/seal.rs
@@ -21,7 +21,7 @@
 
 #![doc = include_str!("seals.md")]
 
-use bp::seals::txout::CloseMethod;
+use bp::seals::txout::{BlindSeal, CloseMethod, SealTxid};
 use bp::secp256k1::rand::{thread_rng, RngCore};
 use bp::Vout;
 use commit_verify::Conceal;
@@ -170,4 +170,8 @@ pub enum BuilderSeal<Seal: TxoSeal + Ord> {
     Revealed(XChain<Seal>),
     #[from]
     Concealed(XChain<SecretSeal>),
+}
+
+impl<Id: SealTxid> From<XChain<BlindSeal<Id>>> for BuilderSeal<BlindSeal<Id>> {
+    fn from(seal: XChain<BlindSeal<Id>>) -> Self { BuilderSeal::Revealed(seal) }
 }

--- a/src/containers/transfer.rs
+++ b/src/containers/transfer.rs
@@ -73,9 +73,14 @@ impl CommitEncode for Transfer {
             writer = self.contract_id().strict_encode(writer)?;
             for (bundle_id, terminal) in &self.terminals {
                 writer = bundle_id.strict_encode(writer)?;
-                let seals =
-                    SmallOrdSet::try_from_iter(terminal.seals.iter().map(TerminalSeal::conceal))
-                        .expect("same size iterator");
+                let seals = SmallOrdSet::try_from_iter(
+                    terminal
+                        .as_reduced_unsafe()
+                        .seals
+                        .iter()
+                        .map(TerminalSeal::conceal),
+                )
+                .expect("same size iterator");
                 writer = seals.strict_encode(writer)?;
             }
             for attach_id in self.attachments.keys() {

--- a/src/containers/util.rs
+++ b/src/containers/util.rs
@@ -20,8 +20,7 @@
 // limitations under the License.
 
 use amplify::confinement::SmallOrdSet;
-use bp::{Outpoint, Tx};
-use rgb::XChain;
+use bp::Tx;
 
 use super::TerminalSeal;
 use crate::LIB_NAME_RGB_STD;
@@ -70,5 +69,3 @@ pub enum ContainerVer {
     #[default]
     V2 = 2,
 }
-
-pub type XOutpoint = XChain<Outpoint>;

--- a/src/containers/util.rs
+++ b/src/containers/util.rs
@@ -20,9 +20,8 @@
 // limitations under the License.
 
 use amplify::confinement::SmallOrdSet;
-use bp::seals::txout::ExplicitSeal;
-use bp::{Outpoint, Tx, Txid};
-use rgb::{OutputSeal, XSeal};
+use bp::{Outpoint, Tx};
+use rgb::XChain;
 
 use super::TerminalSeal;
 use crate::LIB_NAME_RGB_STD;
@@ -72,45 +71,4 @@ pub enum ContainerVer {
     V2 = 2,
 }
 
-#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display)]
-#[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
-#[strict_type(lib = LIB_NAME_RGB_STD, tags = custom, dumb = Self::Bitcoin(strict_dumb!()))]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(crate = "serde_crate", rename_all = "camelCase")
-)]
-#[non_exhaustive]
-pub enum XchainOutpoint {
-    #[strict_type(tag = 0x00)]
-    #[display("bitcoin:{0}", alt = "{0}")]
-    Bitcoin(Outpoint),
-
-    #[strict_type(tag = 0x01)]
-    #[display("liquid:{0}")]
-    Liquid(Outpoint),
-    /*
-    #[strict_type(tag = 0x10)]
-    Abraxas,
-    #[strict_type(tag = 0x11)]
-    Prime,
-     */
-}
-
-impl From<OutputSeal> for XchainOutpoint {
-    fn from(seal: OutputSeal) -> Self {
-        match seal {
-            OutputSeal::Bitcoin(s) => XchainOutpoint::Bitcoin(s.into()),
-            OutputSeal::Liquid(s) => XchainOutpoint::Liquid(s.into()),
-        }
-    }
-}
-
-impl From<XchainOutpoint> for XSeal<ExplicitSeal<Txid>> {
-    fn from(outpoint: XchainOutpoint) -> Self {
-        match outpoint {
-            XchainOutpoint::Bitcoin(outpoint) => XSeal::Bitcoin(outpoint.into()),
-            XchainOutpoint::Liquid(outpoint) => XSeal::Liquid(outpoint.into()),
-        }
-    }
-}
+pub type XOutpoint = XChain<Outpoint>;

--- a/src/containers/validate.rs
+++ b/src/containers/validate.rs
@@ -19,12 +19,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rgb::validation::{ResolveTx, Validator, Validity, Warning};
+use rgb::validation::{ResolveWitness, Validator, Validity, Warning};
 
 use super::{Consignment, IndexedConsignment};
 
 impl<const TYPE: bool> Consignment<TYPE> {
-    pub fn validate<R: ResolveTx>(
+    pub fn validate<R: ResolveWitness>(
         mut self,
         resolver: &mut R,
         testnet: bool,

--- a/src/interface/builder.rs
+++ b/src/interface/builder.rs
@@ -319,6 +319,8 @@ impl TransitionBuilder {
         })
     }
 
+    pub fn transition_type(&self) -> TransitionType { self.transition_type }
+
     #[inline]
     pub fn add_asset_tag(
         mut self,

--- a/src/interface/contract.rs
+++ b/src/interface/contract.rs
@@ -26,13 +26,12 @@ use amplify::confinement::{LargeOrdMap, LargeVec, SmallVec};
 use bp::Outpoint;
 use rgb::{
     AssetTag, AssignmentType, AttachId, BlindingFactor, ContractId, ContractState, FungibleOutput,
-    MediaType, RevealedAttach, RevealedData, WitnessId, XOutputSeal,
+    MediaType, RevealedAttach, RevealedData, WitnessId, XOutpoint, XOutputSeal,
 };
 use strict_encoding::FieldName;
 use strict_types::typify::TypedVal;
 use strict_types::{decode, StrictVal};
 
-use crate::containers::XOutpoint;
 use crate::interface::{IfaceId, IfaceImpl};
 
 #[derive(Clone, Eq, PartialEq, Debug, Display, Error, From)]

--- a/src/interface/contract.rs
+++ b/src/interface/contract.rs
@@ -233,7 +233,7 @@ impl ContractIface {
             .fungibles()
             .iter()
             .filter(|outp| outp.opout.ty == type_id)
-            .filter(|outp| filter.include_output(outp.seal.map(Outpoint::from)))
+            .filter(|outp| filter.include_output(outp.seal))
             .map(FungibleAllocation::from);
         Ok(LargeVec::try_from_iter(state).expect("same or smaller collection size"))
     }

--- a/src/interface/contract.rs
+++ b/src/interface/contract.rs
@@ -26,13 +26,13 @@ use amplify::confinement::{LargeOrdMap, LargeVec, SmallVec};
 use bp::Outpoint;
 use rgb::{
     AssetTag, AssignmentType, AttachId, BlindingFactor, ContractId, ContractState, FungibleOutput,
-    MediaType, OutputSeal, RevealedAttach, RevealedData, WitnessId,
+    MediaType, RevealedAttach, RevealedData, WitnessId, XOutputSeal,
 };
 use strict_encoding::FieldName;
 use strict_types::typify::TypedVal;
 use strict_types::{decode, StrictVal};
 
-use crate::containers::XchainOutpoint;
+use crate::containers::XOutpoint;
 use crate::interface::{IfaceId, IfaceImpl};
 
 #[derive(Clone, Eq, PartialEq, Debug, Display, Error, From)]
@@ -105,7 +105,7 @@ impl From<Option<WitnessId>> for AllocationWitness {
 // TODO: Consider removing type in favour of `FungibleOutput`
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct FungibleAllocation {
-    pub owner: OutputSeal,
+    pub owner: XOutputSeal,
     pub witness: AllocationWitness,
     pub value: u64,
 }
@@ -125,26 +125,26 @@ impl From<&FungibleOutput> for FungibleAllocation {
 }
 
 pub trait OutpointFilter {
-    fn include_output(&self, output: impl Into<XchainOutpoint>) -> bool;
+    fn include_output(&self, output: impl Into<XOutpoint>) -> bool;
 }
 
 pub struct FilterIncludeAll;
 pub struct FilterExclude<T: OutpointFilter>(pub T);
 
 impl<T: OutpointFilter> OutpointFilter for &T {
-    fn include_output(&self, output: impl Into<XchainOutpoint>) -> bool {
+    fn include_output(&self, output: impl Into<XOutpoint>) -> bool {
         (*self).include_output(output)
     }
 }
 
 impl<T: OutpointFilter> OutpointFilter for &mut T {
-    fn include_output(&self, output: impl Into<XchainOutpoint>) -> bool {
+    fn include_output(&self, output: impl Into<XOutpoint>) -> bool {
         self.deref().include_output(output)
     }
 }
 
 impl<T: OutpointFilter> OutpointFilter for Option<T> {
-    fn include_output(&self, output: impl Into<XchainOutpoint>) -> bool {
+    fn include_output(&self, output: impl Into<XOutpoint>) -> bool {
         self.as_ref()
             .map(|filter| filter.include_output(output))
             .unwrap_or(true)
@@ -152,37 +152,29 @@ impl<T: OutpointFilter> OutpointFilter for Option<T> {
 }
 
 impl OutpointFilter for FilterIncludeAll {
-    fn include_output(&self, _: impl Into<XchainOutpoint>) -> bool { true }
+    fn include_output(&self, _: impl Into<XOutpoint>) -> bool { true }
 }
 
 impl<T: OutpointFilter> OutpointFilter for FilterExclude<T> {
-    fn include_output(&self, output: impl Into<XchainOutpoint>) -> bool {
+    fn include_output(&self, output: impl Into<XOutpoint>) -> bool {
         !self.0.include_output(output.into())
     }
 }
 
-impl OutpointFilter for &[XchainOutpoint] {
-    fn include_output(&self, output: impl Into<XchainOutpoint>) -> bool {
-        self.contains(&output.into())
-    }
+impl OutpointFilter for &[XOutpoint] {
+    fn include_output(&self, output: impl Into<XOutpoint>) -> bool { self.contains(&output.into()) }
 }
 
-impl OutpointFilter for Vec<XchainOutpoint> {
-    fn include_output(&self, output: impl Into<XchainOutpoint>) -> bool {
-        self.contains(&output.into())
-    }
+impl OutpointFilter for Vec<XOutpoint> {
+    fn include_output(&self, output: impl Into<XOutpoint>) -> bool { self.contains(&output.into()) }
 }
 
-impl OutpointFilter for HashSet<XchainOutpoint> {
-    fn include_output(&self, output: impl Into<XchainOutpoint>) -> bool {
-        self.contains(&output.into())
-    }
+impl OutpointFilter for HashSet<XOutpoint> {
+    fn include_output(&self, output: impl Into<XOutpoint>) -> bool { self.contains(&output.into()) }
 }
 
-impl OutpointFilter for BTreeSet<XchainOutpoint> {
-    fn include_output(&self, output: impl Into<XchainOutpoint>) -> bool {
-        self.contains(&output.into())
-    }
+impl OutpointFilter for BTreeSet<XOutpoint> {
+    fn include_output(&self, output: impl Into<XOutpoint>) -> bool { self.contains(&output.into()) }
 }
 
 /// Contract state is an in-memory structure providing API to read structured
@@ -241,7 +233,7 @@ impl ContractIface {
             .fungibles()
             .iter()
             .filter(|outp| outp.opout.ty == type_id)
-            .filter(|outp| filter.include_output(outp.seal))
+            .filter(|outp| filter.include_output(outp.seal.map(Outpoint::from)))
             .map(FungibleAllocation::from);
         Ok(LargeVec::try_from_iter(state).expect("same or smaller collection size"))
     }

--- a/src/persistence/hoard.rs
+++ b/src/persistence/hoard.rs
@@ -48,6 +48,9 @@ pub enum ConsumeError {
     #[from]
     Anchor(mpc::InvalidProof),
 
+    #[display("anchor set {0} contains inconsistent information on witness id")]
+    AnchorInconsistent(WitnessId),
+
     #[from]
     Merge(MergeError),
 
@@ -213,7 +216,9 @@ impl Hoard {
         &mut self,
         anchor: XAnchor<mpc::MerkleBlock>,
     ) -> Result<(), ConsumeError> {
-        let witness_id = anchor.witness_id();
+        let witness_id = anchor
+            .witness_id()
+            .ok_or_else(|| ConsumeError::AnchorInconsistent(anchor.witness_id_unchecked()))?;
         match self.anchors.get_mut(&witness_id) {
             Some(a) => *a = a.clone().merge_reveal(anchor)?,
             None => {

--- a/src/persistence/inventory.rs
+++ b/src/persistence/inventory.rs
@@ -716,6 +716,7 @@ pub trait Inventory: Deref<Target = Self::Stash> {
     /// Composes a batch of state transitions updating state for the provided
     /// set of previous outputs, satisfying requirements of the invoice, paying
     /// the change back and including the necessary blank state transitions.
+    #[allow(clippy::too_many_arguments)]
     fn compose_deterministic(
         &self,
         invoice: &RgbInvoice,

--- a/src/persistence/inventory.rs
+++ b/src/persistence/inventory.rs
@@ -33,14 +33,14 @@ use invoice::{Beneficiary, InvoiceState, RgbInvoice};
 use rgb::{
     validation, AnchoredBundle, AssignmentType, BlindingFactor, BundleId, ContractId, GraphSeal,
     OpId, Operation, Opout, SchemaId, SecretSeal, SubSchema, Transition, TransitionBundle,
-    WitnessId, XAnchor, XChain, XOutputSeal,
+    WitnessId, XAnchor, XChain, XOutpoint, XOutputSeal,
 };
 use strict_encoding::TypeName;
 
 use crate::accessors::{BundleExt, MergeRevealError, RevealError};
 use crate::containers::{
     Batch, Bindle, BuilderSeal, Cert, Consignment, ContentId, Contract, Fascia, Terminal,
-    TerminalSeal, Transfer, TransitionInfo, XOutpoint,
+    TerminalSeal, Transfer, TransitionInfo,
 };
 use crate::interface::{
     BuilderError, ContractIface, Iface, IfaceId, IfaceImpl, IfacePair, IfaceWrapper,

--- a/src/persistence/stock.rs
+++ b/src/persistence/stock.rs
@@ -29,8 +29,8 @@ use rgb::validation::{Status, Validity, Warning};
 use rgb::{
     validation, AnchoredBundle, Assign, AssignmentType, BundleId, ContractHistory, ContractId,
     ContractState, ExposedState, Extension, Genesis, GenesisSeal, GraphSeal, OpId, Operation,
-    Opout, OutputSeal, SecretSeal, SubSchema, Transition, TransitionBundle, TypedAssigns,
-    WitnessAnchor, WitnessId, XAnchor, XSeal,
+    Opout, SecretSeal, SubSchema, Transition, TransitionBundle, TypedAssigns, WitnessAnchor,
+    WitnessId, XAnchor, XChain, XOutputSeal,
 };
 use strict_encoding::{StrictDeserialize, StrictSerialize};
 
@@ -38,6 +38,7 @@ use crate::containers::{Bindle, Cert, Consignment, ContentId, Contract, Terminal
 use crate::interface::{
     ContractIface, Iface, IfaceId, IfaceImpl, IfacePair, SchemaIfaces, TypedState,
 };
+use crate::persistence::hoard::ConsumeError;
 use crate::persistence::inventory::{DataError, IfaceImplError, InventoryInconsistency};
 use crate::persistence::{
     Hoard, Inventory, InventoryDataError, InventoryError, Stash, StashInconsistency,
@@ -55,7 +56,7 @@ pub struct IndexedBundle(ContractId, BundleId);
 #[strict_type(lib = LIB_NAME_RGB_STD)]
 pub struct ContractIndex {
     public_opouts: MediumOrdSet<Opout>,
-    outpoint_opouts: MediumOrdMap<OutputSeal, MediumOrdSet<Opout>>,
+    outpoint_opouts: MediumOrdMap<XOutputSeal, MediumOrdSet<Opout>>,
 }
 
 /// Stock is an in-memory inventory (stash, index, contract state) useful for
@@ -75,9 +76,9 @@ pub struct Stock {
     bundle_op_index: MediumOrdMap<OpId, IndexedBundle>,
     anchor_bundle_index: MediumOrdMap<BundleId, WitnessId>,
     contract_index: TinyOrdMap<ContractId, ContractIndex>,
-    terminal_index: MediumOrdMap<SecretSeal, Opout>,
+    terminal_index: MediumOrdMap<XChain<SecretSeal>, Opout>,
     // secrets
-    seal_secrets: MediumOrdSet<XSeal<GraphSeal>>,
+    seal_secrets: MediumOrdSet<XChain<GraphSeal>>,
 }
 
 impl Default for Stock {
@@ -152,7 +153,14 @@ impl Stock {
 
         // clone needed due to borrow checker
         for (bundle_id, terminal) in consignment.terminals.clone() {
-            for secret in terminal.seals.iter().filter_map(TerminalSeal::secret_seal) {
+            let layer1 = terminal.layer1();
+            for secret in terminal
+                .as_reduced_unsafe()
+                .seals
+                .iter()
+                .filter_map(TerminalSeal::secret_seal)
+            {
+                let secret = XChain::with(layer1, secret);
                 if let Some(seal) = self.seal_secrets.iter().find(|s| s.conceal() == secret) {
                     consignment.reveal_bundle_seal(bundle_id, *seal);
                 }
@@ -175,7 +183,9 @@ impl Stock {
         }
         for AnchoredBundle { anchor, bundle } in &mut consignment.bundles {
             let bundle_id = bundle.bundle_id();
-            let witness_id = anchor.witness_id();
+            let witness_id = anchor
+                .witness_id()
+                .ok_or_else(|| ConsumeError::AnchorInconsistent(anchor.witness_id_unchecked()))?;
             self.anchor_bundle_index.insert(bundle_id, witness_id)?;
             self.index_bundle(contract_id, bundle, witness_id)?;
         }
@@ -466,7 +476,9 @@ impl Inventory for Stock {
         &mut self,
         anchor: XAnchor<mpc::MerkleBlock>,
     ) -> Result<(), InventoryError<Self::Error>> {
-        let witness_id = anchor.witness_id();
+        let witness_id = anchor
+            .witness_id()
+            .ok_or_else(|| ConsumeError::AnchorInconsistent(anchor.witness_id_unchecked()))?;
         for (bundle_id, _) in anchor.known_bundle_ids() {
             self.anchor_bundle_index.insert(bundle_id, witness_id)?;
         }
@@ -568,7 +580,7 @@ impl Inventory for Stock {
 
     fn contracts_by_outputs(
         &self,
-        outputs: impl IntoIterator<Item = impl Into<OutputSeal>>,
+        outputs: impl IntoIterator<Item = impl Into<XOutputSeal>>,
     ) -> Result<BTreeSet<ContractId>, InventoryError<Self::Error>> {
         let outputs = outputs
             .into_iter()
@@ -599,7 +611,7 @@ impl Inventory for Stock {
     fn opouts_by_outputs(
         &self,
         contract_id: ContractId,
-        outputs: impl IntoIterator<Item = impl Into<OutputSeal>>,
+        outputs: impl IntoIterator<Item = impl Into<XOutputSeal>>,
     ) -> Result<BTreeSet<Opout>, InventoryError<Self::Error>> {
         let index = self
             .contract_index
@@ -618,7 +630,7 @@ impl Inventory for Stock {
 
     fn opouts_by_terminals(
         &self,
-        terminals: impl IntoIterator<Item = SecretSeal>,
+        terminals: impl IntoIterator<Item = XChain<SecretSeal>>,
     ) -> Result<BTreeSet<Opout>, InventoryError<Self::Error>> {
         let terminals = terminals.into_iter().collect::<BTreeSet<_>>();
         Ok(self
@@ -632,8 +644,8 @@ impl Inventory for Stock {
     fn state_for_outputs(
         &self,
         contract_id: ContractId,
-        outputs: impl IntoIterator<Item = impl Into<OutputSeal>>,
-    ) -> Result<BTreeMap<(Opout, OutputSeal), TypedState>, InventoryError<Self::Error>> {
+        outputs: impl IntoIterator<Item = impl Into<XOutputSeal>>,
+    ) -> Result<BTreeMap<(Opout, XOutputSeal), TypedState>, InventoryError<Self::Error>> {
         let outputs = outputs
             .into_iter()
             .map(|o| o.into())
@@ -685,13 +697,13 @@ impl Inventory for Stock {
 
     fn store_seal_secret(
         &mut self,
-        seal: XSeal<GraphSeal>,
+        seal: XChain<GraphSeal>,
     ) -> Result<(), InventoryError<Self::Error>> {
         self.seal_secrets.push(seal)?;
         Ok(())
     }
 
-    fn seal_secrets(&self) -> Result<BTreeSet<XSeal<GraphSeal>>, InventoryError<Self::Error>> {
+    fn seal_secrets(&self) -> Result<BTreeSet<XChain<GraphSeal>>, InventoryError<Self::Error>> {
         Ok(self.seal_secrets.to_inner())
     }
 }

--- a/src/persistence/stock.rs
+++ b/src/persistence/stock.rs
@@ -34,7 +34,9 @@ use rgb::{
 };
 use strict_encoding::{StrictDeserialize, StrictSerialize};
 
-use crate::containers::{Bindle, Cert, Consignment, ContentId, Contract, TerminalSeal, Transfer};
+use crate::containers::{
+    Bindle, Cert, Consignment, ContentId, Contract, TerminalSeal, Transfer, XOutpoint,
+};
 use crate::interface::{
     ContractIface, Iface, IfaceId, IfaceImpl, IfacePair, SchemaIfaces, TypedState,
 };
@@ -641,10 +643,10 @@ impl Inventory for Stock {
             .collect())
     }
 
-    fn state_for_outputs(
+    fn state_for_outpoints(
         &self,
         contract_id: ContractId,
-        outputs: impl IntoIterator<Item = impl Into<XOutputSeal>>,
+        outputs: impl IntoIterator<Item = impl Into<XOutpoint>>,
     ) -> Result<BTreeMap<(Opout, XOutputSeal), TypedState>, InventoryError<Self::Error>> {
         let outputs = outputs
             .into_iter()
@@ -659,7 +661,7 @@ impl Inventory for Stock {
         let mut res = BTreeMap::new();
 
         for item in history.fungibles() {
-            if outputs.contains(&item.seal) {
+            if outputs.contains(&item.seal.into()) {
                 res.insert(
                     (item.opout, item.seal),
                     TypedState::Amount(
@@ -672,19 +674,19 @@ impl Inventory for Stock {
         }
 
         for item in history.data() {
-            if outputs.contains(&item.seal) {
+            if outputs.contains(&item.seal.into()) {
                 res.insert((item.opout, item.seal), TypedState::Data(item.state.clone()));
             }
         }
 
         for item in history.rights() {
-            if outputs.contains(&item.seal) {
+            if outputs.contains(&item.seal.into()) {
                 res.insert((item.opout, item.seal), TypedState::Void);
             }
         }
 
         for item in history.attach() {
-            if outputs.contains(&item.seal) {
+            if outputs.contains(&item.seal.into()) {
                 res.insert(
                     (item.opout, item.seal),
                     TypedState::Attachment(item.state.clone().into()),

--- a/src/persistence/stock.rs
+++ b/src/persistence/stock.rs
@@ -30,13 +30,11 @@ use rgb::{
     validation, AnchoredBundle, Assign, AssignmentType, BundleId, ContractHistory, ContractId,
     ContractState, ExposedState, Extension, Genesis, GenesisSeal, GraphSeal, OpId, Operation,
     Opout, SecretSeal, SubSchema, Transition, TransitionBundle, TypedAssigns, WitnessAnchor,
-    WitnessId, XAnchor, XChain, XOutputSeal,
+    WitnessId, XAnchor, XChain, XOutpoint, XOutputSeal,
 };
 use strict_encoding::{StrictDeserialize, StrictSerialize};
 
-use crate::containers::{
-    Bindle, Cert, Consignment, ContentId, Contract, TerminalSeal, Transfer, XOutpoint,
-};
+use crate::containers::{Bindle, Cert, Consignment, ContentId, Contract, TerminalSeal, Transfer};
 use crate::interface::{
     ContractIface, Iface, IfaceId, IfaceImpl, IfacePair, SchemaIfaces, TypedState,
 };

--- a/src/stl/stl.rs
+++ b/src/stl/stl.rs
@@ -44,7 +44,7 @@ pub const LIB_ID_RGB_CONTRACT: &str =
 
 /// Strict types id for the library representing of RGB StdLib data types.
 pub const LIB_ID_RGB_STD: &str =
-    "urn:ubideco:stl:FjdM8g7HN2S8hfKB17GuwsnKRzFM9up8bJ4uBNzWAPDL#aloha-olivia-rider";
+    "urn:ubideco:stl:452BoxLkej33Myvj2ygScjX72Nphpm4tbtiHwP4ET7Xw#proxy-james-scratch";
 
 fn _rgb_std_stl() -> Result<TypeLib, CompileError> {
     LibBuilder::new(libname!(LIB_NAME_RGB_STD), tiny_bset! {

--- a/stl/RGBStd@0.1.0.sty
+++ b/stl/RGBStd@0.1.0.sty
@@ -65,7 +65,7 @@ import urn:ubideco:stl:EZiZRCHpyqJakmTU1zkwczq5YKMbapfMhVLhS8DbkpwC#premium-hone
 -- AltLayer1Set := urn:ubideco:semid:3Sruah3S3s7c8XRpD8bN7c8rnSKemwvnxhocQzHy5D9m#manual-cycle-circus
 -- VoidState := urn:ubideco:semid:49HkbZvGaJE3phHjLBMQCR3NK1sGA462HJr5BkqQ6YQr#nectar-ceramic-driver
 -- AnchorSet := urn:ubideco:semid:4GL38RVDhs4JkL5phqyF6pguwL6Av8qTUWCVNfGeWdUg#history-joel-ivory
--- XSealBlindSealTxPtr := urn:ubideco:semid:4Nr4GNjqYM4KpeLkWEFjy8FxYs1jVV6CCum7CMftHCm9#studio-evening-camera
+-- XChainBlindSealTxPtr := urn:ubideco:semid:4Nr4GNjqYM4KpeLkWEFjy8FxYs1jVV6CCum7CMftHCm9#studio-evening-camera
 -- TransitionType := urn:ubideco:semid:4XEmzMLZTXc4XB3njvemMq5qdMmx5EKJPAXpJaBPrqCb#puma-joshua-evita
 -- Occurrences := urn:ubideco:semid:4gjtVBchJQ5f1aAzoyxYWeGp6qZi9dPudJCbWKYKhw1a#unicorn-empire-mama
 -- StateSchema := urn:ubideco:semid:4pgZ5NMvRK6Jf2ua7H3TCF8bMNHhZR7PuUJawqq1X4uG#yoga-arizona-flex
@@ -75,7 +75,7 @@ import urn:ubideco:stl:EZiZRCHpyqJakmTU1zkwczq5YKMbapfMhVLhS8DbkpwC#premium-hone
 -- GlobalValues := urn:ubideco:semid:5j3xo5bTKFzcKayBQELdAVzUEnuPPAVd8etsBPG1EgZ3#volcano-expand-paper
 -- ValencyType := urn:ubideco:semid:5mswXMrudHpJEnuoLA86YY2VHN5iL56hmKcmh5k1h3e5#palma-exit-pupil
 -- PedersenCommitment := urn:ubideco:semid:5twbh2U5hyaowidwum1iRNCqebBLxTuZTuNPt3SaRT13#nepal-delta-earth
--- XSealExplicitSeal := urn:ubideco:semid:5yxE75Qk7ScEuNdG4NXGASsGkpyUVQB3FVaxm3q8w1zK#carbon-network-hilton
+-- XChainExplicitSeal := urn:ubideco:semid:5yxE75Qk7ScEuNdG4NXGASsGkpyUVQB3FVaxm3q8w1zK#carbon-network-hilton
 -- AssignRevealedValueBlindSealTxid := urn:ubideco:semid:6McV9ZYuRYX11q6DnALBt7uYo6yxoFjDWocYeXnsEUJc#cotton-david-edition
 -- ExtensionType := urn:ubideco:semid:7m9MHRdHSXnhYiheDeXybxnHAxPRgs84USnVELFH98Cd#mission-salsa-parole
 -- Transition := urn:ubideco:semid:7pNXtZVVpUHTSZi9UiyPWWRDvKsRzdyByntYcyytnwVy#data-wedding-night
@@ -90,7 +90,7 @@ import urn:ubideco:stl:EZiZRCHpyqJakmTU1zkwczq5YKMbapfMhVLhS8DbkpwC#premium-hone
 -- BlindingFactor := urn:ubideco:semid:9zzp5XyDaLvZSGhCEWtey1Y7xdD1soEYdGaimjyZexyf#agenda-ivory-blast
 -- AssignmentType := urn:ubideco:semid:A9sThAqgwKPfuJcR4GDfTQHUAbbS5sbEXG5XVk7FZHEg#hunter-hello-retro
 -- AssignVoidStateBlindSealTxPtr := urn:ubideco:semid:ACfDgeTtorFy3NqZWw6CuWHNKT3hpuXpwFHV9DpjLoT1#campus-front-carpet
--- XSealBlindSealTxid := urn:ubideco:semid:Age9RPnuptagg4d8Q6wixptyT6y6yRFvTSWEkrT6H6Vc#ford-guitar-tonight
+-- XChainBlindSealTxid := urn:ubideco:semid:Age9RPnuptagg4d8Q6wixptyT6y6yRFvTSWEkrT6H6Vc#ford-guitar-tonight
 -- AssignmentsBlindSealTxid := urn:ubideco:semid:AkbqFDMkiwdiUVmhPaBmq2D4RkeGqb4bB7jq5JTA3AQV#radio-sherman-cabinet
 -- Opout := urn:ubideco:semid:Au5jXjVgXjeE2n7dFQnPQwjLRQJ3eoGygRvt8ppzXrfx#india-joshua-adam
 -- SchemaId := urn:ubideco:semid:AyzbMn4ux89LLU8ho1L4pQa5TXsmRdHd79oh6SXdrCmd#garcia-smoke-ozone
@@ -225,7 +225,7 @@ data ContentId        :: schema RGB.SchemaId {- urn:ubideco:semid:AyzbMn4ux89LLU
 -- urn:ubideco:semid:72v5XvfiTB7HJinscrxy5ZTa4PwubG9YCtkK8JQt7F5B#denver-almanac-cobalt
 data ContentSigs      :: {Cert ^ 1..0xa}
 -- urn:ubideco:semid:EFPmZdw9YNzrqSdx9buUBvoUmXAzEho94rfP9phgpTx5#license-infant-bicycle
-data ContractIndex    :: publicOpouts {RGB.Opout {- urn:ubideco:semid:Au5jXjVgXjeE2n7dFQnPQwjLRQJ3eoGygRvt8ppzXrfx#india-joshua-adam -} ^ ..0xffffff}, outpointOpouts {RGB.XSealExplicitSeal -> ^ ..0xffffff {RGB.Opout {- urn:ubideco:semid:Au5jXjVgXjeE2n7dFQnPQwjLRQJ3eoGygRvt8ppzXrfx#india-joshua-adam -} ^ ..0xffffff}}
+data ContractIndex    :: publicOpouts {RGB.Opout {- urn:ubideco:semid:Au5jXjVgXjeE2n7dFQnPQwjLRQJ3eoGygRvt8ppzXrfx#india-joshua-adam -} ^ ..0xffffff}, outpointOpouts {RGB.XChainExplicitSeal -> ^ ..0xffffff {RGB.Opout {- urn:ubideco:semid:Au5jXjVgXjeE2n7dFQnPQwjLRQJ3eoGygRvt8ppzXrfx#india-joshua-adam -} ^ ..0xffffff}}
 -- urn:ubideco:semid:3WPrDGfcJCVwN9ZtFUf1w6SqsutP7xuJ8wRdby9VgPHF#slang-mars-belgium
 data ContractSuppl    :: contractId RGB.ContractId {- urn:ubideco:semid:Bho42Xw8wPy2nWxgz6H51rNdBBusaPyrVQT8VypvpZ3w#alarm-danube-vampire -}
                        , ticker TickerSuppl
@@ -338,7 +338,7 @@ data Stock            :: hoard Hoard
                        , anchorBundleIndex {RGB.BundleId -> ^ ..0xffffff RGB.WitnessId {- urn:ubideco:semid:EEYT7goTNgX2nNFoKosg6FKx1CDSyFWHKNK1TRySs6gr#axiom-gyro-album -}}
                        , contractIndex {RGB.ContractId -> ^ ..0xff ContractIndex}
                        , terminalIndex {BPCore.SecretSeal -> ^ ..0xffffff RGB.Opout {- urn:ubideco:semid:Au5jXjVgXjeE2n7dFQnPQwjLRQJ3eoGygRvt8ppzXrfx#india-joshua-adam -}}
-                       , sealSecrets {RGB.XSealBlindSealTxPtr {- urn:ubideco:semid:4Nr4GNjqYM4KpeLkWEFjy8FxYs1jVV6CCum7CMftHCm9#studio-evening-camera -} ^ ..0xffffff}
+                       , sealSecrets {RGB.XChainBlindSealTxPtr {- urn:ubideco:semid:4Nr4GNjqYM4KpeLkWEFjy8FxYs1jVV6CCum7CMftHCm9#studio-evening-camera -} ^ ..0xffffff}
 -- urn:ubideco:semid:7wqgZas6f6Y7jWyDzLNxCeGEM8NXppB1f1gZNvNHJD72#partner-austin-dinner
 data SupplId          :: [Byte ^ 32]
 -- urn:ubideco:semid:CXGPwRETAtPV783GHQKZmnpvrtbUzELpBP74ScXDBP22#system-billy-polaris


### PR DESCRIPTION
Blind UTXO ("secret seals") was not properly supporting cross-chain seal definitions. This resulted in the bug where the accepted consignment was not recognized as its own state.

The core of the fix is in https://github.com/RGB-WG/rgb-core/pull/199, as well as in https://github.com/BP-WG/bp-core/pull/71

This required making blind UTXOs commit to the chain. I used this as an opportunity to embed multi-chain support to RGB invoices and combine it with testnet etc indications. So now, the beneficiary in the invoice ALWAYS contains information on both network and chain, using new prefixes: `bc`, `tb`, `lq`, `tl` etc:
1) if the beneficiary is an address, it will look like `bc:1pj6fx-pzy9gy-xl6mek-j7fxgm-h3frl5-fwulrf-lawxpt-vve6jv-h4vles-hh8wut` or `bc:18cBEM-RxXHqz-WWCxZN-tU91F5-sbUNKh-L5PX`
2) if the beneficiary is blind seal, now it will contain this additional prefx in front: `bc:utxob:....`