### PR TITLE
Fungible operation history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,7 @@ dependencies = [
 [[package]]
 name = "rgb-core"
 version = "0.11.0-beta.4"
-source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#b1232f5f77ff253bbe79bdcee04a2cf0d4ef0c05"
+source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#2b59903039770df4766c9681bc74691382308ef5"
 dependencies = [
  "aluvm",
  "amplify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,7 @@ dependencies = [
 [[package]]
 name = "rgb-core"
 version = "0.11.0-beta.4"
-source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#f1454499c2a9eda8e85ae473b954d7f8c227b930"
+source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#6b93ada6d5668458b0c4dccdde132f56f5e662cc"
 dependencies = [
  "aluvm",
  "amplify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,7 @@ dependencies = [
 [[package]]
 name = "rgb-core"
 version = "0.11.0-beta.4"
-source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#6b93ada6d5668458b0c4dccdde132f56f5e662cc"
+source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#b1232f5f77ff253bbe79bdcee04a2cf0d4ef0c05"
 dependencies = [
  "aluvm",
  "amplify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,8 +655,7 @@ dependencies = [
 [[package]]
 name = "rgb-core"
 version = "0.11.0-beta.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb0581f9bc33b509400aa9225d2308dfd45af413a4fe38f7c4b823a7e09e6036"
+source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#f1454499c2a9eda8e85ae473b954d7f8c227b930"
 dependencies = [
  "aluvm",
  "amplify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,3 +91,6 @@ wasm-bindgen-test = "0.3"
 
 [package.metadata.docs.rs]
 features = [ "all" ]
+
+[patch.crates-io]
+rgb-core = { git = "https://github.com/RGB-WG/rgb-core", branch = "v0.11" }

--- a/invoice/src/amount.rs
+++ b/invoice/src/amount.rs
@@ -24,6 +24,7 @@ use std::fmt::{Display, Formatter, Write};
 use std::iter::Sum;
 
 use bp::Sats;
+use rgb::{KnownState, RevealedValue};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use strict_encoding::{StrictDeserialize, StrictSerialize};
@@ -54,6 +55,12 @@ pub struct Amount(
 
 impl StrictSerialize for Amount {}
 impl StrictDeserialize for Amount {}
+
+impl KnownState for Amount {}
+
+impl From<RevealedValue> for Amount {
+    fn from(value: RevealedValue) -> Self { Amount(value.value.as_u64()) }
+}
 
 impl Amount {
     pub const ZERO: Self = Amount(0);

--- a/invoice/src/amount.rs
+++ b/invoice/src/amount.rs
@@ -24,7 +24,7 @@ use std::fmt::{Display, Formatter, Write};
 use std::iter::Sum;
 
 use bp::Sats;
-use rgb::{KnownState, RevealedValue};
+use rgb::{FungibleState, KnownState, RevealedValue};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use strict_encoding::{StrictDeserialize, StrictSerialize};
@@ -60,6 +60,14 @@ impl KnownState for Amount {}
 
 impl From<RevealedValue> for Amount {
     fn from(value: RevealedValue) -> Self { Amount(value.value.as_u64()) }
+}
+
+impl From<FungibleState> for Amount {
+    fn from(state: FungibleState) -> Self { Amount(state.as_u64()) }
+}
+
+impl From<Amount> for FungibleState {
+    fn from(amount: Amount) -> Self { FungibleState::Bits64(amount.0) }
 }
 
 impl Amount {

--- a/invoice/src/builder.rs
+++ b/invoice/src/builder.rs
@@ -24,7 +24,9 @@ use std::str::FromStr;
 use rgb::ContractId;
 use strict_encoding::{FieldName, TypeName};
 
-use super::{Beneficiary, InvoiceState, Precision, RgbInvoice, RgbTransport, TransportParseError};
+use super::{
+    Amount, Beneficiary, InvoiceState, Precision, RgbInvoice, RgbTransport, TransportParseError,
+};
 use crate::invoice::XChainNet;
 
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -78,8 +80,8 @@ impl RgbInvoiceBuilder {
         self
     }
 
-    pub fn set_amount_raw(mut self, amount: u64) -> Self {
-        self.0.owned_state = InvoiceState::Amount(amount);
+    pub fn set_amount_raw(mut self, amount: impl Into<Amount>) -> Self {
+        self.0.owned_state = InvoiceState::Amount(amount.into());
         self
     }
 

--- a/invoice/src/invoice.rs
+++ b/invoice/src/invoice.rs
@@ -24,6 +24,8 @@ use invoice::{AddressNetwork, AddressPayload, Network};
 use rgb::{AttachId, ContractId, Layer1, SecretSeal};
 use strict_encoding::{FieldName, TypeName};
 
+use crate::Amount;
+
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 #[non_exhaustive]
 pub enum RgbTransport {
@@ -39,7 +41,7 @@ pub enum InvoiceState {
     #[display("")]
     Void,
     #[display("{0}")]
-    Amount(u64),
+    Amount(Amount),
     #[display("...")] // TODO
     Data(Vec<u8> /* StrictVal */),
     #[display(inner)]

--- a/invoice/src/parse.rs
+++ b/invoice/src/parse.rs
@@ -31,7 +31,7 @@ use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use rgb::{ContractId, SecretSeal};
 use strict_encoding::{InvalidIdent, TypeName};
 
-use super::{Beneficiary, InvoiceState, RgbInvoice, RgbTransport};
+use super::{Amount, Beneficiary, InvoiceState, RgbInvoice, RgbTransport};
 use crate::invoice::{ChainNet, XChainNet};
 
 const OMITTED: &str = "~";
@@ -353,7 +353,7 @@ impl FromStr for RgbInvoice {
             .unwrap_or((Some(assignment.as_str()), None));
         // TODO: support other state types
         let (beneficiary_str, value) = match (amount, beneficiary) {
-            (Some(a), Some(b)) => (b, InvoiceState::Amount(a.parse::<u64>()?)),
+            (Some(a), Some(b)) => (b, InvoiceState::Amount(a.parse::<Amount>()?)),
             (Some(b), None) => (b, InvoiceState::Void),
             _ => unreachable!(),
         };

--- a/src/interface/filters.rs
+++ b/src/interface/filters.rs
@@ -19,7 +19,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::ops::Deref;
 
 use rgb::{AssignmentWitness, XOutpoint};
@@ -99,6 +99,20 @@ impl OutpointFilter for BTreeSet<XOutpoint> {
     }
 }
 
+impl<V> OutpointFilter for HashMap<XOutpoint, V> {
+    fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool {
+        let outpoint = outpoint.into();
+        self.keys().any(|o| *o == outpoint)
+    }
+}
+
+impl<V> OutpointFilter for BTreeMap<XOutpoint, V> {
+    fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool {
+        let outpoint = outpoint.into();
+        self.keys().any(|o| *o == outpoint)
+    }
+}
+
 // WitnessFilter
 
 impl WitnessFilter for FilterIncludeAll {
@@ -164,5 +178,19 @@ impl WitnessFilter for HashSet<AssignmentWitness> {
 impl WitnessFilter for BTreeSet<AssignmentWitness> {
     fn include_witness(&self, witness: impl Into<AssignmentWitness>) -> bool {
         self.contains(&witness.into())
+    }
+}
+
+impl<V> WitnessFilter for HashMap<AssignmentWitness, V> {
+    fn include_witness(&self, witness: impl Into<AssignmentWitness>) -> bool {
+        let witness = witness.into();
+        self.keys().any(|w| *w == witness)
+    }
+}
+
+impl<V> WitnessFilter for BTreeMap<AssignmentWitness, V> {
+    fn include_witness(&self, witness: impl Into<AssignmentWitness>) -> bool {
+        let witness = witness.into();
+        self.keys().any(|w| *w == witness)
     }
 }

--- a/src/interface/filters.rs
+++ b/src/interface/filters.rs
@@ -33,7 +33,17 @@ pub trait OutpointFilter {
 }
 
 pub struct FilterIncludeAll;
-pub struct FilterExclude<T: OutpointFilter>(pub T);
+pub struct FilterExclude<T>(pub T);
+
+impl OutpointFilter for FilterIncludeAll {
+    fn include_outpoint(&self, _: impl Into<XOutpoint>) -> bool { true }
+}
+
+impl<T: OutpointFilter> OutpointFilter for FilterExclude<T> {
+    fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool {
+        !self.0.include_outpoint(outpoint.into())
+    }
+}
 
 impl<T: OutpointFilter> OutpointFilter for &T {
     fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool {
@@ -52,16 +62,6 @@ impl<T: OutpointFilter> OutpointFilter for Option<T> {
         self.as_ref()
             .map(|filter| filter.include_outpoint(outpoint))
             .unwrap_or(true)
-    }
-}
-
-impl OutpointFilter for FilterIncludeAll {
-    fn include_outpoint(&self, _: impl Into<XOutpoint>) -> bool { true }
-}
-
-impl<T: OutpointFilter> OutpointFilter for FilterExclude<T> {
-    fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool {
-        !self.0.include_outpoint(outpoint.into())
     }
 }
 
@@ -96,5 +96,73 @@ impl OutpointFilter for HashSet<XOutpoint> {
 impl OutpointFilter for BTreeSet<XOutpoint> {
     fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool {
         self.contains(&outpoint.into())
+    }
+}
+
+// WitnessFilter
+
+impl WitnessFilter for FilterIncludeAll {
+    fn include_witness(&self, _: impl Into<AssignmentWitness>) -> bool { true }
+}
+
+impl<T: WitnessFilter> WitnessFilter for FilterExclude<T> {
+    fn include_witness(&self, witness: impl Into<AssignmentWitness>) -> bool {
+        !self.0.include_witness(witness.into())
+    }
+}
+
+impl<T: WitnessFilter> WitnessFilter for &T {
+    fn include_witness(&self, witness: impl Into<AssignmentWitness>) -> bool {
+        (*self).include_witness(witness)
+    }
+}
+
+impl<T: WitnessFilter> WitnessFilter for &mut T {
+    fn include_witness(&self, witness: impl Into<AssignmentWitness>) -> bool {
+        self.deref().include_witness(witness)
+    }
+}
+
+impl<T: WitnessFilter> WitnessFilter for Option<T> {
+    fn include_witness(&self, witness: impl Into<AssignmentWitness>) -> bool {
+        self.as_ref()
+            .map(|filter| filter.include_witness(witness))
+            .unwrap_or(true)
+    }
+}
+
+impl WitnessFilter for AssignmentWitness {
+    fn include_witness(&self, witness: impl Into<AssignmentWitness>) -> bool {
+        *self == witness.into()
+    }
+}
+
+impl<const LEN: usize> WitnessFilter for [AssignmentWitness; LEN] {
+    fn include_witness(&self, witness: impl Into<AssignmentWitness>) -> bool {
+        self.contains(&witness.into())
+    }
+}
+
+impl WitnessFilter for &[AssignmentWitness] {
+    fn include_witness(&self, witness: impl Into<AssignmentWitness>) -> bool {
+        self.contains(&witness.into())
+    }
+}
+
+impl WitnessFilter for Vec<AssignmentWitness> {
+    fn include_witness(&self, witness: impl Into<AssignmentWitness>) -> bool {
+        self.contains(&witness.into())
+    }
+}
+
+impl WitnessFilter for HashSet<AssignmentWitness> {
+    fn include_witness(&self, witness: impl Into<AssignmentWitness>) -> bool {
+        self.contains(&witness.into())
+    }
+}
+
+impl WitnessFilter for BTreeSet<AssignmentWitness> {
+    fn include_witness(&self, witness: impl Into<AssignmentWitness>) -> bool {
+        self.contains(&witness.into())
     }
 }

--- a/src/interface/filters.rs
+++ b/src/interface/filters.rs
@@ -1,0 +1,100 @@
+// RGB standard library for working with smart contracts on Bitcoin & Lightning
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Written in 2019-2023 by
+//     Dr Maxim Orlovsky <orlovsky@lnp-bp.org>
+//
+// Copyright (C) 2019-2023 LNP/BP Standards Association. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{BTreeSet, HashSet};
+use std::ops::Deref;
+
+use rgb::{AssignmentWitness, XOutpoint};
+
+pub trait WitnessFilter {
+    fn include_witness(&self, witness: impl Into<AssignmentWitness>) -> bool;
+}
+
+pub trait OutpointFilter {
+    fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool;
+}
+
+pub struct FilterIncludeAll;
+pub struct FilterExclude<T: OutpointFilter>(pub T);
+
+impl<T: OutpointFilter> OutpointFilter for &T {
+    fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool {
+        (*self).include_outpoint(outpoint)
+    }
+}
+
+impl<T: OutpointFilter> OutpointFilter for &mut T {
+    fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool {
+        self.deref().include_outpoint(outpoint)
+    }
+}
+
+impl<T: OutpointFilter> OutpointFilter for Option<T> {
+    fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool {
+        self.as_ref()
+            .map(|filter| filter.include_outpoint(outpoint))
+            .unwrap_or(true)
+    }
+}
+
+impl OutpointFilter for FilterIncludeAll {
+    fn include_outpoint(&self, _: impl Into<XOutpoint>) -> bool { true }
+}
+
+impl<T: OutpointFilter> OutpointFilter for FilterExclude<T> {
+    fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool {
+        !self.0.include_outpoint(outpoint.into())
+    }
+}
+
+impl OutpointFilter for XOutpoint {
+    fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool { *self == outpoint.into() }
+}
+
+impl<const LEN: usize> OutpointFilter for [XOutpoint; LEN] {
+    fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool {
+        self.contains(&outpoint.into())
+    }
+}
+
+impl OutpointFilter for &[XOutpoint] {
+    fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool {
+        self.contains(&outpoint.into())
+    }
+}
+
+impl OutpointFilter for Vec<XOutpoint> {
+    fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool {
+        self.contains(&outpoint.into())
+    }
+}
+
+impl OutpointFilter for HashSet<XOutpoint> {
+    fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool {
+        self.contains(&outpoint.into())
+    }
+}
+
+impl OutpointFilter for BTreeSet<XOutpoint> {
+    fn include_outpoint(&self, outpoint: impl Into<XOutpoint>) -> bool {
+        self.contains(&outpoint.into())
+    }
+}

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -34,8 +34,9 @@ mod suppl;
 
 pub use builder::{BuilderError, ContractBuilder, TransitionBuilder};
 pub use contract::{
-    AttachAllocation, AttachedState, ContractError, ContractIface, DataAllocation, FilterExclude,
-    FilterIncludeAll, FungibleAllocation, IfaceWrapper, OutpointFilter, RightsAllocation,
+    AllocatedState, AttachAllocation, AttachedState, ContractError, ContractIface, DataAllocation,
+    FilterExclude, FilterIncludeAll, FungibleAllocation, IfaceWrapper, OutpointFilter,
+    OwnedAllocation, RightsAllocation,
 };
 pub use iface::{
     ArgMap, ArgSpec, AssignIface, ExtensionIface, GenesisIface, GlobalIface, Iface, IfaceId,

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -32,10 +32,10 @@ pub mod rgb21;
 pub mod rgb25;
 mod suppl;
 
-pub use builder::{BuilderError, BuilderState, ContractBuilder, TransitionBuilder};
+pub use builder::{BuilderError, ContractBuilder, TransitionBuilder};
 pub use contract::{
-    ContractError, ContractIface, DataAllocation, FilterExclude, FilterIncludeAll,
-    FungibleAllocation, IfaceWrapper, OutpointFilter, RightsAllocation,
+    AttachAllocation, AttachedState, ContractError, ContractIface, DataAllocation, FilterExclude,
+    FilterIncludeAll, FungibleAllocation, IfaceWrapper, OutpointFilter, RightsAllocation,
 };
 pub use iface::{
     ArgMap, ArgSpec, AssignIface, ExtensionIface, GenesisIface, GlobalIface, Iface, IfaceId,

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -31,13 +31,14 @@ pub mod rgb20;
 pub mod rgb21;
 pub mod rgb25;
 mod suppl;
+mod filters;
 
 pub use builder::{BuilderError, ContractBuilder, TransitionBuilder};
 pub use contract::{
     AllocatedState, AttachAllocation, AttachedState, ContractError, ContractIface, DataAllocation,
-    FilterExclude, FilterIncludeAll, FungibleAllocation, IfaceOp, IfaceWrapper, OutpointFilter,
-    OwnedAllocation, RightsAllocation, StateChange, WitnessFilter,
+    FungibleAllocation, IfaceOp, IfaceWrapper, OwnedAllocation, RightsAllocation, StateChange,
 };
+pub use filters::{FilterExclude, FilterIncludeAll, OutpointFilter, WitnessFilter};
 pub use iface::{
     ArgMap, ArgSpec, AssignIface, ExtensionIface, GenesisIface, GlobalIface, Iface, IfaceId,
     OwnedIface, Req, TransitionIface, ValencyIface,

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -32,10 +32,10 @@ pub mod rgb21;
 pub mod rgb25;
 mod suppl;
 
-pub use builder::{BuilderError, ContractBuilder, TransitionBuilder};
+pub use builder::{BuilderError, BuilderState, ContractBuilder, TransitionBuilder};
 pub use contract::{
-    AllocationWitness, ContractError, ContractIface, FilterExclude, FilterIncludeAll,
-    FungibleAllocation, IfaceWrapper, OutpointFilter, TypedState,
+    ContractError, ContractIface, DataAllocation, FilterExclude, FilterIncludeAll,
+    FungibleAllocation, IfaceWrapper, OutpointFilter, RightsAllocation,
 };
 pub use iface::{
     ArgMap, ArgSpec, AssignIface, ExtensionIface, GenesisIface, GlobalIface, Iface, IfaceId,

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -43,7 +43,7 @@ pub use iface::{
     OwnedIface, Req, TransitionIface, ValencyIface,
 };
 pub use iimpl::{IfaceImpl, IfacePair, ImplId, NamedField, NamedType, SchemaIfaces};
-pub use rgb20::{rgb20, rgb20_stl, Rgb20, LIB_ID_RGB20, LIB_NAME_RGB20};
+pub use rgb20::{rgb20, rgb20_stl, AmountChange, Rgb20, LIB_ID_RGB20, LIB_NAME_RGB20};
 pub use rgb21::{rgb21, rgb21_stl, Rgb21, LIB_ID_RGB21, LIB_NAME_RGB21};
 pub use rgb25::{rgb25, rgb25_stl, Rgb25, LIB_ID_RGB25, LIB_NAME_RGB25};
 pub use suppl::{ContractSuppl, OwnedStateSuppl, SupplId, TickerSuppl, VelocityHint};

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -35,8 +35,8 @@ mod suppl;
 pub use builder::{BuilderError, ContractBuilder, TransitionBuilder};
 pub use contract::{
     AllocatedState, AttachAllocation, AttachedState, ContractError, ContractIface, DataAllocation,
-    FilterExclude, FilterIncludeAll, FungibleAllocation, IfaceWrapper, OutpointFilter,
-    OwnedAllocation, RightsAllocation,
+    FilterExclude, FilterIncludeAll, FungibleAllocation, IfaceOp, IfaceWrapper, OutpointFilter,
+    OwnedAllocation, RightsAllocation, StateChange, WitnessFilter,
 };
 pub use iface::{
     ArgMap, ArgSpec, AssignIface, ExtensionIface, GenesisIface, GlobalIface, Iface, IfaceId,

--- a/src/interface/rgb20.rs
+++ b/src/interface/rgb20.rs
@@ -19,7 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amplify::confinement::LargeVec;
 use bp::bc::stl::bp_tx_stl;
 use invoice::Amount;
 use strict_types::{CompileError, LibBuilder, TypeLib};
@@ -275,12 +274,14 @@ impl Rgb20 {
 
     pub fn balance(&self, filter: &impl OutpointFilter) -> Amount {
         self.allocations(filter)
-            .iter()
-            .map(|alloc| alloc.value)
+            .map(|alloc| alloc.state)
             .sum::<Amount>()
     }
 
-    pub fn allocations(&self, filter: &impl OutpointFilter) -> LargeVec<FungibleAllocation> {
+    pub fn allocations<'c, 'f: 'c>(
+        &'c self,
+        filter: &'f impl OutpointFilter,
+    ) -> impl Iterator<Item = FungibleAllocation> + 'c {
         self.0
             .fungible("assetOwner", filter)
             .expect("RGB20 interface requires `assetOwner` state")

--- a/src/interface/rgb20.rs
+++ b/src/interface/rgb20.rs
@@ -330,15 +330,15 @@ impl Rgb20 {
         Timestamp::from_strict_val_unchecked(strict_val)
     }
 
-    pub fn balance(&self, filter: &impl OutpointFilter) -> Amount {
+    pub fn balance(&self, filter: impl OutpointFilter) -> Amount {
         self.allocations(filter)
             .map(|alloc| alloc.state)
             .sum::<Amount>()
     }
 
-    pub fn allocations<'c, 'f: 'c>(
+    pub fn allocations<'c>(
         &'c self,
-        filter: &'f impl OutpointFilter,
+        filter: impl OutpointFilter + 'c,
     ) -> impl Iterator<Item = FungibleAllocation> + 'c {
         self.0
             .fungible("assetOwner", filter)

--- a/src/interface/rgb20.rs
+++ b/src/interface/rgb20.rs
@@ -261,12 +261,11 @@ pub enum AmountChange {
 impl StateChange for AmountChange {
     type State = Amount;
 
-    fn from_spent(state: Self::State) -> Self { AmountChange::Dec(state.into()) }
+    fn from_spent(state: Self::State) -> Self { AmountChange::Dec(state) }
 
-    fn from_received(state: Self::State) -> Self { AmountChange::Inc(state.into()) }
+    fn from_received(state: Self::State) -> Self { AmountChange::Inc(state) }
 
-    fn merge_spent(&mut self, state: Self::State) {
-        let sub = Amount::from(state);
+    fn merge_spent(&mut self, sub: Self::State) {
         *self = match self {
             AmountChange::Dec(neg) => AmountChange::Dec(*neg + sub),
             AmountChange::Zero => AmountChange::Dec(sub),
@@ -277,8 +276,7 @@ impl StateChange for AmountChange {
         };
     }
 
-    fn merge_received(&mut self, state: Self::State) {
-        let add = Amount::from(state);
+    fn merge_received(&mut self, add: Self::State) {
         *self = match self {
             AmountChange::Inc(pos) => AmountChange::Inc(*pos + add),
             AmountChange::Zero => AmountChange::Inc(add),

--- a/src/interface/rgb21.rs
+++ b/src/interface/rgb21.rs
@@ -101,6 +101,10 @@ impl Allocation {
     pub fn with(index: TokenIndex, fraction: OwnedFraction) -> Allocation {
         Allocation(index, fraction)
     }
+
+    pub fn token_index(self) -> TokenIndex { self.0 }
+
+    pub fn fraction(self) -> OwnedFraction { self.1 }
 }
 
 impl StrictSerialize for Allocation {}

--- a/src/persistence/hoard.rs
+++ b/src/persistence/hoard.rs
@@ -35,7 +35,9 @@ use strict_encoding::TypeName;
 
 use crate::accessors::{MergeReveal, MergeRevealError};
 use crate::containers::{Cert, Consignment, ContentId, ContentSigs};
-use crate::interface::{rgb20, ContractSuppl, Iface, IfaceId, IfacePair, SchemaIfaces};
+use crate::interface::{
+    rgb20, rgb21, rgb25, ContractSuppl, Iface, IfaceId, IfacePair, SchemaIfaces,
+};
 use crate::persistence::{InventoryError, Stash, StashError, StashInconsistency};
 use crate::LIB_NAME_RGB_STD;
 
@@ -86,10 +88,16 @@ impl Hoard {
     pub fn preset() -> Self {
         let rgb20 = rgb20();
         let rgb20_id = rgb20.iface_id();
+        let rgb21 = rgb21();
+        let rgb21_id = rgb21.iface_id();
+        let rgb25 = rgb25();
+        let rgb25_id = rgb25.iface_id();
         Hoard {
             schemata: none!(),
             ifaces: tiny_bmap! {
                 rgb20_id => rgb20,
+                rgb21_id => rgb21,
+                rgb25_id => rgb25,
             },
             geneses: none!(),
             suppl: none!(),

--- a/src/persistence/inventory.rs
+++ b/src/persistence/inventory.rs
@@ -507,13 +507,28 @@ pub trait Inventory: Deref<Target = Self::Stash> {
         let schema_ifaces = self.contract_schema(contract_id)?;
         let iface = self.iface_by_name(&iface.into())?;
         let schema = &schema_ifaces.schema;
-        let iimpl = schema_ifaces
-            .iimpls
-            .get(&iface.iface_id())
-            .ok_or(DataError::NoIfaceImpl(schema.schema_id(), iface.iface_id()))?;
-        let builder =
+        if schema_ifaces.iimpls.is_empty() {
+            return Err(InventoryError::DataError(DataError::NoIfaceImpl(
+                schema.schema_id(),
+                iface.iface_id(),
+            )));
+        }
+
+        let builder = if let Some(iimpl) = schema_ifaces.iimpls.get(&iface.iface_id()) {
             TransitionBuilder::blank_transition(iface.clone(), schema.clone(), iimpl.clone())
-                .expect("internal inconsistency");
+                .expect("internal inconsistency")
+        } else {
+            let (default_iface_id, default_iimpl) = schema_ifaces.iimpls.first_key_value().unwrap();
+            let default_iface = self.iface_by_id(*default_iface_id)?;
+
+            TransitionBuilder::blank_transition(
+                default_iface.clone(),
+                schema.clone(),
+                default_iimpl.clone(),
+            )
+            .expect("internal inconsistency")
+        };
+
         Ok(builder)
     }
 

--- a/src/persistence/inventory.rs
+++ b/src/persistence/inventory.rs
@@ -514,7 +514,7 @@ pub trait Inventory: Deref<Target = Self::Stash> {
             )));
         }
 
-        let builder = if let Some(iimpl) = schema_ifaces.iimpls.get(&iface.iface_id()) {
+        let mut builder = if let Some(iimpl) = schema_ifaces.iimpls.get(&iface.iface_id()) {
             TransitionBuilder::blank_transition(iface.clone(), schema.clone(), iimpl.clone())
                 .expect("internal inconsistency")
         } else {
@@ -528,6 +528,12 @@ pub trait Inventory: Deref<Target = Self::Stash> {
             )
             .expect("internal inconsistency")
         };
+        let tags = self.contract_asset_tags(contract_id)?;
+        for (assignment_type, asset_tag) in tags {
+            builder = builder
+                .add_asset_tag_raw(*assignment_type, *asset_tag)
+                .expect("tags are in bset and must not repeat");
+        }
 
         Ok(builder)
     }

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -36,6 +36,7 @@ mod stash;
 mod inventory;
 pub mod stock;
 pub mod hoard;
+mod state;
 
 pub use hoard::Hoard;
 pub use inventory::{
@@ -43,4 +44,5 @@ pub use inventory::{
     InventoryInconsistency,
 };
 pub use stash::{Stash, StashError, StashInconsistency};
+pub use state::PresistedState;
 pub use stock::Stock;

--- a/src/persistence/state.rs
+++ b/src/persistence/state.rs
@@ -1,0 +1,44 @@
+// RGB standard library for working with smart contracts on Bitcoin & Lightning
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Written in 2019-2023 by
+//     Dr Maxim Orlovsky <orlovsky@lnp-bp.org>
+//
+// Copyright (C) 2019-2023 LNP/BP Standards Association. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use invoice::Amount;
+use rgb::{AssetTag, BlindingFactor, DataState};
+
+use crate::interface::AttachedState;
+
+#[derive(Clone, Eq, PartialEq, Debug, Hash)]
+pub enum PresistedState {
+    Void,
+    Amount(Amount, BlindingFactor, AssetTag),
+    Data(DataState, u128),
+    Attachment(AttachedState, u64),
+}
+
+impl PresistedState {
+    pub(super) fn update_blinding(&mut self, blinding: BlindingFactor) {
+        match self {
+            PresistedState::Void => {}
+            PresistedState::Amount(_, b, _) => *b = blinding,
+            PresistedState::Data(_, _) => {}
+            PresistedState::Attachment(_, _) => {}
+        }
+    }
+}

--- a/src/persistence/stock.rs
+++ b/src/persistence/stock.rs
@@ -36,7 +36,7 @@ use strict_encoding::{StrictDeserialize, StrictSerialize};
 
 use crate::containers::{Bindle, Cert, Consignment, ContentId, Contract, TerminalSeal, Transfer};
 use crate::interface::{
-    ContractIface, Iface, IfaceId, IfaceImpl, IfacePair, SchemaIfaces, TypedState,
+    BuilderState, ContractIface, Iface, IfaceId, IfaceImpl, IfacePair, SchemaIfaces,
 };
 use crate::persistence::hoard::ConsumeError;
 use crate::persistence::inventory::{DataError, IfaceImplError, InventoryInconsistency};
@@ -645,7 +645,7 @@ impl Inventory for Stock {
         &self,
         contract_id: ContractId,
         outputs: impl IntoIterator<Item = impl Into<XOutpoint>>,
-    ) -> Result<BTreeMap<(Opout, XOutputSeal), TypedState>, InventoryError<Self::Error>> {
+    ) -> Result<BTreeMap<(Opout, XOutputSeal), BuilderState>, InventoryError<Self::Error>> {
         let outputs = outputs
             .into_iter()
             .map(|o| o.into())
@@ -662,7 +662,7 @@ impl Inventory for Stock {
             if outputs.contains(&item.seal.into()) {
                 res.insert(
                     (item.opout, item.seal),
-                    TypedState::Amount(
+                    BuilderState::Amount(
                         item.state.value.as_u64(),
                         item.state.blinding,
                         item.state.tag,
@@ -673,13 +673,13 @@ impl Inventory for Stock {
 
         for item in history.data() {
             if outputs.contains(&item.seal.into()) {
-                res.insert((item.opout, item.seal), TypedState::Data(item.state.clone()));
+                res.insert((item.opout, item.seal), BuilderState::Data(item.state.clone()));
             }
         }
 
         for item in history.rights() {
             if outputs.contains(&item.seal.into()) {
-                res.insert((item.opout, item.seal), TypedState::Void);
+                res.insert((item.opout, item.seal), BuilderState::Void);
             }
         }
 
@@ -687,7 +687,7 @@ impl Inventory for Stock {
             if outputs.contains(&item.seal.into()) {
                 res.insert(
                     (item.opout, item.seal),
-                    TypedState::Attachment(item.state.clone().into()),
+                    BuilderState::Attachment(item.state.clone().into()),
                 );
             }
         }

--- a/src/stl/error.rs
+++ b/src/stl/error.rs
@@ -23,6 +23,7 @@ use amplify::IoError;
 use baid58::Baid58ParseError;
 use strict_types::{typesys, CompileError};
 
+#[allow(dead_code)]
 #[derive(Debug, From)]
 pub(super) enum Error {
     #[from(std::io::Error)]

--- a/src/stl/stl.rs
+++ b/src/stl/stl.rs
@@ -44,7 +44,7 @@ pub const LIB_ID_RGB_CONTRACT: &str =
 
 /// Strict types id for the library representing of RGB StdLib data types.
 pub const LIB_ID_RGB_STD: &str =
-    "urn:ubideco:stl:452BoxLkej33Myvj2ygScjX72Nphpm4tbtiHwP4ET7Xw#proxy-james-scratch";
+    "urn:ubideco:stl:2JeGRjYkHUAwYTKhWUVnZvLYhUtsHWrYUqRhWY8cd8pJ#harris-bottle-alcohol";
 
 fn _rgb_std_stl() -> Result<TypeLib, CompileError> {
     LibBuilder::new(libname!(LIB_NAME_RGB_STD), tiny_bset! {

--- a/src/stl/stl.rs
+++ b/src/stl/stl.rs
@@ -44,7 +44,7 @@ pub const LIB_ID_RGB_CONTRACT: &str =
 
 /// Strict types id for the library representing of RGB StdLib data types.
 pub const LIB_ID_RGB_STD: &str =
-    "urn:ubideco:stl:2JeGRjYkHUAwYTKhWUVnZvLYhUtsHWrYUqRhWY8cd8pJ#harris-bottle-alcohol";
+    "urn:ubideco:stl:GWQoxySX59F4FHGxNdpKN4uKT8bkVyquvk3uz6pyQdP3#profit-escort-karl";
 
 fn _rgb_std_stl() -> Result<TypeLib, CompileError> {
     LibBuilder::new(libname!(LIB_NAME_RGB_STD), tiny_bset! {


### PR DESCRIPTION
Prerequisites for https://github.com/RGB-WG/rgb/pull/92. Include:
- new concept of witness filters;
- new concept of state change types which help to track past operation effects
- `AmountChange`: a case of state change type which tracks the change in the balance as an effect of past fungible transfers
- refactored typed states
- `ContractIface::fungible_ops` command reconstructing history of operations affecting some fungible state (with changes expressed as AmountChange)
- `Rgb20::transfer_history` wrapper which simplifies the call for RGB20-interfaces contracts