### PR TITLE
fix blank_builder to avoid AssetTagMissed error

### DIFF
--- a/src/persistence/inventory.rs
+++ b/src/persistence/inventory.rs
@@ -514,7 +514,7 @@ pub trait Inventory: Deref<Target = Self::Stash> {
             )));
         }
 
-        let builder = if let Some(iimpl) = schema_ifaces.iimpls.get(&iface.iface_id()) {
+        let mut builder = if let Some(iimpl) = schema_ifaces.iimpls.get(&iface.iface_id()) {
             TransitionBuilder::blank_transition(iface.clone(), schema.clone(), iimpl.clone())
                 .expect("internal inconsistency")
         } else {
@@ -528,6 +528,12 @@ pub trait Inventory: Deref<Target = Self::Stash> {
             )
             .expect("internal inconsistency")
         };
+        let tags = self.contract_asset_tags(contract_id)?;
+        for (assignment_type, asset_tag) in tags {
+            builder = builder
+                .add_asset_tag_raw(*assignment_type, *asset_tag)
+                .expect("tags are in bset and must not repeat");
+        }
 
         Ok(builder)
     }


### PR DESCRIPTION
When sending an asset allocated to an UTXO that has also other assets allocated we need to construct the blank transitions (using the `blank_builder` method).
But when doing
```rust
blank_builder = blank_builder
    .add_input(opout, state.clone())?
    .add_owned_state_raw(opout.ty, seal, state)?;
```
the call to `add_owned_state_raw` raises the `AssetTagMissed` error (from the internal call to the `asset_tag` method), because `self.asset_tags` is empty.
With the proposed fix this error doesn't arise anymore. The fix consists in calling `add_asset_tag_raw` the same way it's currently done in the `transition_builder` method.
