### PR TITLE
Support to non-fungible invoices and readable precision

### DIFF
--- a/invoice/src/builder.rs
+++ b/invoice/src/builder.rs
@@ -24,10 +24,8 @@ use std::str::FromStr;
 use rgb::ContractId;
 use strict_encoding::{FieldName, TypeName};
 
-use super::{
-    Amount, Beneficiary, InvoiceState, Precision, RgbInvoice, RgbTransport, TransportParseError,
-};
-use crate::invoice::XChainNet;
+use crate::invoice::{Beneficiary, InvoiceState, RgbInvoice, RgbTransport, XChainNet};
+use crate::{Allocation, Amount, NonFungible, Precision, TransportParseError};
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct RgbInvoiceBuilder(RgbInvoice);
@@ -105,6 +103,15 @@ impl RgbInvoiceBuilder {
              decimals has digits at most, so overflow is not possible",
         );
         Ok(self.set_amount_raw(amount))
+    }
+
+    pub fn set_allocation_raw(mut self, allocation: impl Into<Allocation>) -> Self {
+        self.0.owned_state = InvoiceState::Data(NonFungible::RGB21(allocation.into()));
+        self
+    }
+
+    pub fn set_allocation(self, token_index: u32, fraction: u64) -> Result<Self, Self> {
+        Ok(self.set_allocation_raw(Allocation::with(token_index, fraction)))
     }
 
     /// # Safety

--- a/invoice/src/data.rs
+++ b/invoice/src/data.rs
@@ -1,0 +1,107 @@
+use std::str::FromStr;
+
+use rgb::{DataState, KnownState, RevealedData};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+use strict_encoding::{StrictDeserialize, StrictSerialize};
+
+use crate::LIB_NAME_RGB_CONTRACT;
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Display)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate", rename_all = "camelCase")
+)]
+pub enum NonFungible {
+    #[display(inner)]
+    RGB21(Allocation),
+}
+
+impl FromStr for NonFungible {
+    type Err = AllocationParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let allocation = Allocation::from_str(s)?;
+        Ok(NonFungible::RGB21(allocation))
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Display, Error, From)]
+#[display(inner)]
+pub enum AllocationParseError {
+    #[display(doc_comments)]
+    /// invalid token index {0}.
+    InvalidIndex(String),
+
+    #[display(doc_comments)]
+    /// invalid fraction {0}.
+    InvalidFraction(String),
+
+    #[display(doc_comments)]
+    /// allocation must have format <fraction>@<token_index>.
+    WrongFormat,
+}
+
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Default, From, Display)]
+#[derive(StrictType, StrictEncode, StrictDecode)]
+#[strict_type(lib = LIB_NAME_RGB_CONTRACT)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "serde_crate"))]
+#[display("{1}@{0}")]
+pub struct Allocation(u32, u64);
+
+impl StrictSerialize for Allocation {}
+impl StrictDeserialize for Allocation {}
+
+impl KnownState for Allocation {}
+
+impl From<RevealedData> for Allocation {
+    fn from(data: RevealedData) -> Self {
+        Allocation::from_strict_serialized(data.value.into()).expect("invalid allocation data")
+    }
+}
+
+impl From<DataState> for Allocation {
+    fn from(state: DataState) -> Self {
+        Allocation::from_strict_serialized(state.into()).expect("invalid allocation data")
+    }
+}
+
+impl From<Allocation> for DataState {
+    fn from(allocation: Allocation) -> Self {
+        DataState::from(
+            allocation
+                .to_strict_serialized()
+                .expect("invalid allocation data"),
+        )
+    }
+}
+
+impl FromStr for Allocation {
+    type Err = AllocationParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if !s.contains('@') {
+            return Err(AllocationParseError::WrongFormat);
+        }
+
+        match s.split_once('@') {
+            Some((fraction, token_index)) => Ok(Allocation::with(
+                token_index
+                    .parse()
+                    .map_err(|_| AllocationParseError::InvalidIndex(token_index.to_owned()))?,
+                fraction
+                    .parse()
+                    .map_err(|_| AllocationParseError::InvalidFraction(fraction.to_lowercase()))?,
+            )),
+            None => Err(AllocationParseError::WrongFormat),
+        }
+    }
+}
+
+impl Allocation {
+    pub fn with(token_index: u32, fraction: u64) -> Self { Self(token_index, fraction) }
+
+    pub fn token_index(self) -> u32 { self.0 }
+
+    pub fn fraction(self) -> u64 { self.1 }
+}

--- a/invoice/src/lib.rs
+++ b/invoice/src/lib.rs
@@ -34,9 +34,11 @@ mod invoice;
 mod parse;
 mod builder;
 mod amount;
+mod data;
 
 pub use amount::{Amount, CoinAmount, Precision};
 pub use builder::RgbInvoiceBuilder;
+pub use data::{Allocation, NonFungible};
 pub use parse::{InvoiceParseError, TransportParseError};
 
 pub use crate::invoice::{

--- a/src/interface/builder.rs
+++ b/src/interface/builder.rs
@@ -23,7 +23,7 @@ use std::collections::{HashMap, HashSet};
 
 use amplify::confinement::{Confined, TinyOrdMap, TinyOrdSet, U16};
 use amplify::{confinement, Wrapper};
-use invoice::Amount;
+use invoice::{Allocation, Amount};
 use rgb::{
     AltLayer1, AltLayer1Set, AssetTag, Assign, AssignmentType, Assignments, BlindingFactor,
     ContractId, DataState, ExposedSeal, FungibleType, Genesis, GenesisSeal, GlobalState, GraphSeal,
@@ -449,6 +449,18 @@ impl TransitionBuilder {
         self.builder = self
             .builder
             .add_data(name, seal, value, Some(self.transition_type))?;
+        Ok(self)
+    }
+
+    pub fn add_data_raw(
+        mut self,
+        type_id: AssignmentType,
+        seal: impl Into<BuilderSeal<GraphSeal>>,
+        allocation: impl Into<Allocation>,
+        blinding: u64,
+    ) -> Result<Self, BuilderError> {
+        let revelead_state = RevealedData::with_salt(allocation.into(), blinding.into());
+        self.builder = self.builder.add_data_raw(type_id, seal, revelead_state)?;
         Ok(self)
     }
 

--- a/src/interface/contract.rs
+++ b/src/interface/contract.rs
@@ -22,7 +22,7 @@
 use std::collections::HashMap;
 
 use amplify::confinement::{SmallOrdSet, SmallVec};
-use invoice::Amount;
+use invoice::{Allocation, Amount};
 use rgb::{
     AssignmentWitness, AttachId, ContractId, ContractState, DataState, KnownState, MediaType, OpId,
     OutputAssignment, RevealedAttach, RevealedData, RevealedValue, VoidState, WitnessId, XOutpoint,
@@ -69,6 +69,7 @@ pub enum AllocatedState {
 
     #[from]
     #[from(RevealedData)]
+    #[from(Allocation)]
     #[strict_type(tag = 2)]
     Data(DataState),
 
@@ -368,6 +369,23 @@ impl ContractIface {
                 .cloned()
                 .map(OutputAssignment::transmute),
             self.fungible(name, outpoint_filter)?,
+            witness_filter,
+        ))
+    }
+
+    pub fn data_ops<C: StateChange<State = DataState>>(
+        &self,
+        name: impl Into<FieldName>,
+        witness_filter: impl WitnessFilter + Copy,
+        outpoint_filter: impl OutpointFilter + Copy,
+    ) -> Result<HashMap<WitnessId, IfaceOp<C>>, ContractError> {
+        Ok(self.operations(
+            self.state
+                .data()
+                .iter()
+                .cloned()
+                .map(OutputAssignment::transmute),
+            self.data(name, outpoint_filter)?,
             witness_filter,
         ))
     }

--- a/src/stl/chain.rs
+++ b/src/stl/chain.rs
@@ -19,9 +19,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::str::FromStr;
+
 use amplify::confinement::SmallBlob;
 use bp::Outpoint;
 use strict_encoding::{StrictDeserialize, StrictSerialize};
+use strict_types::StrictVal;
 
 use super::LIB_NAME_RGB_CONTRACT;
 
@@ -39,5 +42,14 @@ impl StrictDeserialize for ProofOfReserves {}
 impl ProofOfReserves {
     pub fn new(utxo: Outpoint, proof: SmallBlob) -> ProofOfReserves {
         ProofOfReserves { utxo, proof }
+    }
+
+    pub fn from_strict_val_unchecked(value: &StrictVal) -> Self {
+        let utxo = Outpoint::from_str(&value.unwrap_struct("utxo").unwrap_string())
+            .expect("invalid outpoint");
+        let proof =
+            SmallBlob::from_collection_unsafe(value.unwrap_struct("proof").unwrap_bytes().into());
+
+        Self { utxo, proof }
     }
 }


### PR DESCRIPTION
**Description**

This PR intent solve two issues:

- Add support to data invoice for non-fungible (rgb21, ...)
- Add support to readable precision for fungible (rgb20, rgb25, ...)

Close #133 
Close #121 
