### PR TITLE
fix TransitionBundle merge_reveal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,9 +264,8 @@ dependencies = [
 
 [[package]]
 name = "bp-invoice"
-version = "0.11.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a40b7fb87b58b2371b7b3b010568baa9ba463007707f9af9bb9b77a63d77e8f"
+version = "0.11.0-beta.3.1"
+source = "git+https://github.com/BP-WG/bp-std?branch=v0.11#b37cdba13786091e6e153add0c2beda9c6650ea1"
 dependencies = [
  "amplify",
  "bech32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ strict_encoding = "2.6.2"
 strict_types = "1.6.3"
 commit_verify = { version = "0.11.0-beta.3", features = ["stl"] }
 bp-core = { version = "0.11.0-beta.3", features = ["stl"] }
-bp-invoice = { version = "0.11.0-beta.3" }
+bp-invoice = { version = "0.11.0-beta.3.1" }
 rgb-core = { version = "0.11.0-beta.4", features = ["stl"] }
 indexmap = "2.0.2"
 serde_crate = { package = "serde", version = "1", features = ["derive"] }
@@ -93,4 +93,5 @@ wasm-bindgen-test = "0.3"
 features = [ "all" ]
 
 [patch.crates-io]
+bp-invoice = { git = "https://github.com/BP-WG/bp-std", branch = "v0.11" }
 rgb-core = { git = "https://github.com/RGB-WG/rgb-core", branch = "v0.11" }

--- a/src/accessors/merge_reveal.rs
+++ b/src/accessors/merge_reveal.rs
@@ -188,17 +188,14 @@ impl MergeReveal for TransitionBundle {
     fn merge_reveal(mut self, other: Self) -> Result<Self, MergeRevealError> {
         debug_assert_eq!(self.commitment_id(), other.commitment_id());
 
-        for (opid, transition) in self.known_transitions.keyed_values_mut() {
-            if let Some((_, other_transition)) =
-                other.known_transitions.iter().find(|(o, _)| o == &opid)
-            {
-                transition.assignments = transition
-                    .assignments
-                    .clone()
-                    .merge_reveal(other_transition.assignments.clone())
-                    .unwrap();
+        let mut self_transitions = self.known_transitions.into_inner();
+        for (opid, other_transition) in other.known_transitions {
+            if let Some(mut transition) = self_transitions.remove(&opid) {
+                transition = transition.merge_reveal(other_transition)?;
+                self_transitions.insert(opid, transition);
             }
         }
+        self.known_transitions = Confined::from_collection_unsafe(self_transitions);
 
         if self.input_map.len() > self.known_transitions.len() {
             return Err(MergeRevealError::ExcessiveTransitions);


### PR DESCRIPTION
This PR fixes https://github.com/RGB-WG/rgb/issues/101

The bug was that the method `merge_reveal` (implemented for the `TransitionBundle`) was calling `extend` assuming that `other` had more revealed data than `self`. This is not always the case, so the updated version merges the structures keeping the most revealed condition among the two.