### PR TITLE
fix contract ID for blank transitions

### DIFF
--- a/src/persistence/inventory.rs
+++ b/src/persistence/inventory.rs
@@ -910,7 +910,7 @@ pub trait Inventory: Deref<Target = Self::Stash> {
                     .add_owned_state_raw(opout.ty, seal, state)?;
             }
 
-            let transition = blank_builder.complete_transition(contract_id)?;
+            let transition = blank_builder.complete_transition(id)?;
             blanks.push(TransitionInfo::new(transition, outputs)?)?;
         }
 


### PR DESCRIPTION
This PR fixes the contract ID used for blank transitions.

Fixes https://github.com/RGB-WG/rgb/issues/116