### PR TITLE
convert OperationBuilder map fields to BTreeMap

### DIFF
--- a/src/interface/builder.rs
+++ b/src/interface/builder.rs
@@ -19,7 +19,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 
 use amplify::confinement::{Confined, TinyOrdMap, TinyOrdSet, U16};
 use amplify::{confinement, Wrapper};
@@ -518,10 +518,10 @@ pub struct OperationBuilder<Seal: ExposedSeal> {
     global: GlobalState,
     rights: TinyOrdMap<AssignmentType, Confined<HashSet<BuilderSeal<Seal>>, 1, U16>>,
     fungible:
-        TinyOrdMap<AssignmentType, Confined<HashMap<BuilderSeal<Seal>, RevealedValue>, 1, U16>>,
-    data: TinyOrdMap<AssignmentType, Confined<HashMap<BuilderSeal<Seal>, RevealedData>, 1, U16>>,
+        TinyOrdMap<AssignmentType, Confined<BTreeMap<BuilderSeal<Seal>, RevealedValue>, 1, U16>>,
+    data: TinyOrdMap<AssignmentType, Confined<BTreeMap<BuilderSeal<Seal>, RevealedData>, 1, U16>>,
     attachments:
-        TinyOrdMap<AssignmentType, Confined<HashMap<BuilderSeal<Seal>, RevealedAttach>, 1, U16>>,
+        TinyOrdMap<AssignmentType, Confined<BTreeMap<BuilderSeal<Seal>, RevealedAttach>, 1, U16>>,
     // TODO: add valencies
 }
 


### PR DESCRIPTION
This PR changes the `OperationBuilder` map fields from `HashMap`s to `BTreeMap`s, allowing to construct deterministic transitions (because `BTreeMap` is an ordered map, while with the `HashMap` we cannot guarantee the inserted pairs are always in the same order)