### PR TITLE
Make commit verify semantic id public from crate.

### DIFF
--- a/src/stl/stl.rs
+++ b/src/stl/stl.rs
@@ -21,7 +21,8 @@
 
 use bp::bc::stl::bp_tx_stl;
 use bp::stl::bp_core_stl;
-use commit_verify::stl::commit_verify_stl;
+#[allow(unused_imports)]
+pub use commit_verify::stl::{commit_verify_stl, LIB_ID_COMMIT_VERIFY};
 use invoice::Amount;
 pub use rgb::stl::{aluvm_stl, rgb_core_stl, LIB_ID_RGB};
 use strict_types::stl::{std_stl, strict_types_stl};


### PR DESCRIPTION
For us, semantic IDs are important information, and it'd be helpful if we can expose the commit verify semantic ID. For context, this is our current auto-generated RGB_LIB_IDs.toml file after the RGB 0.11 upgrade:

```
# Auto-generated semantic IDs for RGB consensus-critical libraries and their corresponding versions of bitmask-core.

[LIB_ID_RGB]
# Consensus-breaking: If changed, assets must be reissued
"urn:ubideco:stl:4fGZWR5mH5zZzRZ1r7CSRe776zm3hLBUngfXc4s3vm3V#saturn-flash-emerald" = "0.6.0-rc.17"
"urn:ubideco:stl:141hHBYBr2mzKyskZbRuwazYC9ki5x9ZrrzQHLbgBzx#oscar-rufus-tractor" = "0.7.0-rc.2"

[LIB_ID_RGB_CONTRACT]
# Interface-only: If changed, only a new interface implementation is needed. No reiussance or migration necessary.
"urn:ubideco:stl:6vbr9ZrtsD9aBjo5qRQ36QEZPVucqvRRjKCPqE8yPeJr#choice-little-boxer" = "0.6.0-rc.17"
"urn:ubideco:stl:pGtgmYchjsHEdmKzmkc6SX8rDm4qxN472K8vQyLmNGX#polygon-antonio-violet" = "0.7.0-rc.2"

[LIB_ID_RGB20]
"urn:ubideco:stl:GVz4mvYE94aQ9q2HPtV9VuoppcDdduP54BMKffF7YoFH#prince-scarlet-ringo" = "0.6.0-rc.17"

[LIB_ID_RGB21]
"urn:ubideco:stl:3miGC5GTW58CeuGJgomApmdjm8N6Yu6YuuURS8N4WVBA#opera-cool-bread" = "0.6.0-rc.17"
"urn:ubideco:stl:3HCD3uDCC2EmGASKnxPaFUCgRBT59SbmJkHjkXh8Ht7B#compare-ship-voodoo" = "0.7.0-rc.2"

[LIB_ID_RGB25]
"urn:ubideco:stl:4JmGrg7oTgwuCQtyC4ezC38ToHMzgMCVS5kMSDPwo2ee#camera-betty-bank" = "0.6.0-rc.17"

[LIB_ID_RGB_STD]
# Not consensus-breaking: If changed, only stash and consignments must be updated. No reiussance or migration necessary.
"urn:ubideco:stl:3KXsWZ6hSKRbPjSVwRGbwnwJp3ZNQ2tfe6QUwLJEDG6K#twist-paul-carlo" = "0.6.0-rc.17"
"urn:ubideco:stl:GWQoxySX59F4FHGxNdpKN4uKT8bkVyquvk3uz6pyQdP3#profit-escort-karl" = "0.7.0-rc.2"
```