### PR TITLE
remove check in TransitionBundle::merge_reveal

### DIFF
--- a/src/accessors/merge_reveal.rs
+++ b/src/accessors/merge_reveal.rs
@@ -42,8 +42,8 @@ pub enum MergeRevealError {
     #[display(inner)]
     AnchorMismatch(MergeError),
 
-    /// the merged bundles contain excessive transitions.
-    ExcessiveTransitions,
+    /// the merged bundles contain more transitions than inputs.
+    InsufficientInputs,
 
     /// contract id provided for the merge-reveal operation doesn't matches
     /// multi-protocol commitment.
@@ -197,8 +197,8 @@ impl MergeReveal for TransitionBundle {
         }
         self.known_transitions = Confined::from_collection_unsafe(self_transitions);
 
-        if self.input_map.len() > self.known_transitions.len() {
-            return Err(MergeRevealError::ExcessiveTransitions);
+        if self.input_map.len() < self.known_transitions.len() {
+            return Err(MergeRevealError::InsufficientInputs);
         }
         Ok(self)
     }


### PR DESCRIPTION
This PR removes a check performed in the `TransitionBundle::merge_reveal` method, which makes sure the transition bundle's `input_map` is not longer than the transition bundle's `known_transitions`. The check is making impossible to accept the consignment for the last trasfer in this scenario:

```
       ┌─┐                    ┌─┐              ┌─┐   
       ║"│                    ║"│              ║"│   
       └┬┘                    └┬┘              └┬┘   
       ┌┼┐                    ┌┼┐              ┌┼┐   
        │                      │                │    
       ┌┴┐                    ┌┴┐              ┌┴┐   
      Alice                   Bob            Charlie 
        ────┐                  │                │    
            │ 666 (issuance)   │                │    
        <───┘                  │                │    
        │                      │                │    
        │66 + 132 (468 change) │                │    
        │─────────────────────>│                │    
        │                      │                │    
        │                      │77 (121 change) │    
        │                      │───────────────>│    
        │                      │                │    
        │                      │40 (37 change)  │    
        │                      │<───────────────│    
      Alice                   Bob            Charlie 
       ┌─┐                    ┌─┐              ┌─┐   
       ║"│                    ║"│              ║"│   
       └┬┘                    └┬┘              └┬┘   
       ┌┼┐                    ┌┼┐              ┌┼┐   
        │                      │                │    
       ┌┴┐                    ┌┴┐              ┌┴┐   
```

This seems to happen because:
- the 1st transfer (Alice->Bob) creates 2 RGB allocations
- in the 2nd transfer Bob is using both allocations as inputs, creating a `TransitionBundle` with an `input_map` of lenght 2 and a `known_transitions` of length 1
- in the 3rd transfer, Bob (recipient) already knows the bundle from the 2nd transfer and thus calls `merge_reveal` on it (https://github.com/RGB-WG/rgb-std/blob/948ba0a/src/persistence/hoard.rs#L214), triggering the error
