### PR TITLE
ci: bump msrv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           args: --workspace --all-targets --all-features
 
   msrv-build:
-    name: "MSRV build"
+    name: "toolchains (msrv)"
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [ nightly, beta, stable, 1.69.0 ]
+        toolchain: [ nightly, beta, stable ]
     steps:
       - uses: actions/checkout@v2
       - name: Install rust ${{ matrix.toolchain }}
@@ -85,3 +85,20 @@ jobs:
         with:
           command: check
           args: --workspace --all-targets --all-features
+
+  msrv-build:
+    name: "MSRV build"
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v5
+      - name: Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v2
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Build rgb-std
+        run: nix build
+      - name: Build rgb-invoice
+        run: nix build .#rgb-invoice

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 *.swp
 
 /dep_test
+result

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ homepage = "https://github.com/RGB-WG"
 repository = "https://github.com/RGB-WG/rgb-std"
 keywords = ["bitcoin", "lightning", "rgb", "smart-contracts", "lnp-bp"]
 categories = ["cryptography::cryptocurrencies"]
-rust-version = "1.69.0" # Due to TOML dependency in amplify crate
+rust-version = "1.70.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ by default.
 
 ### MSRV
 
-Minimum supported rust compiler version (MSRV) is shown in `msrv-toolchain.toml`.
+Minimum supported rust compiler version (MSRV) is shown in `rust-version` of `Cargo.toml`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ by default.
 
 ### MSRV
 
-Minimum supported rust compiler version (MSRV): 1.66, rust 2021 edition.
+Minimum supported rust compiler version (MSRV) is shown in `msrv-toolchain.toml`.
 
 ## Contributing
 

--- a/flake.lock
+++ b/flake.lock
@@ -72,11 +72,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712369449,
-        "narHash": "sha256-tbWug3uXPlSm1j0xD80Y3xbP+otT6gLnQo1e/vQat48=",
+        "lastModified": 1712456031,
+        "narHash": "sha256-vPM+DLCyiT3eKGdDBIxqsgBrbbB7lL0TR6R7FLhX1v8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "41b3b080cc3e4b3a48e933b87fc15a05f1870779",
+        "rev": "0e5eaa43f116d798c289b0bb831320a353efc905",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,106 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1712350083,
+        "narHash": "sha256-ghbs9TH41fOL58JAJgdVrZbq3MthffV/twjpv0KYAMY=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "1e44708c0b34380085ba0cbabc230b8adbde1b3a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1712163089,
+        "narHash": "sha256-Um+8kTIrC19vD4/lUCN9/cU9kcOsD1O1m+axJqQPyMM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1712369449,
+        "narHash": "sha256-tbWug3uXPlSm1j0xD80Y3xbP+otT6gLnQo1e/vQat48=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "41b3b080cc3e4b3a48e933b87fc15a05f1870779",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, crane, rust-overlay, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+
+        msrv = builtins.fromTOML (builtins.readFile ./msrv-toolchain.toml);
+        rust = pkgs.rust-bin.stable."${msrv.toolchain.channel}".default;
+        craneLib = (crane.mkLib pkgs).overrideToolchain rust;
+      in
+      with pkgs;
+      {
+        devShell = mkShell {
+          buildInputs = [
+            openssl
+            pkg-config
+            rust
+          ];
+        };
+        packages = rec {
+          default = rgb-std;
+          rgb-std = craneLib.buildPackage {
+            strictDeps = true;
+            src = ./.;
+            cargoExtraArgs = "-p rgb-std";
+            doCheck = false;
+          };
+          rgb-invoice = craneLib.buildPackage {
+            strictDeps = true;
+            src = ./.;
+            cargoExtraArgs = "-p rgb-invoice";
+            doCheck = false;
+          };
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -24,8 +24,8 @@
           inherit system overlays;
         };
 
-        msrv = builtins.fromTOML (builtins.readFile ./msrv-toolchain.toml);
-        rust = pkgs.rust-bin.stable."${msrv.toolchain.channel}".default;
+        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+        rust = pkgs.rust-bin.stable."${cargoToml.workspace.package."rust-version"}".default;
         craneLib = (crane.mkLib pkgs).overrideToolchain rust;
       in
       with pkgs;

--- a/msrv-toolchain.toml
+++ b/msrv-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.70.0"

--- a/msrv-toolchain.toml
+++ b/msrv-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.70.0"


### PR DESCRIPTION
`rgb-core v0.11.0-beta.5` requires rustc 1.70.0 or newer, so the msrv bump.  The msrv mentioned in README is incorrect with the 1.66 version, but the ci is using 1.69.0 as msrv.

To avoid this issue in the future, the msrv will be based on `rust-version` of `Cargo.toml` as the single source of truth, the readme will refer to the file, and the ci will read the file and check on the build of msrv.