### PR TITLE
fix bug: when build consign, override terminal

### DIFF
--- a/src/persistence/stock.rs
+++ b/src/persistence/stock.rs
@@ -170,19 +170,25 @@ pub enum ConsignError {
 impl<S: StashProvider, H: StateProvider, P: IndexProvider> From<ConsignError>
     for StockError<S, H, P, ConsignError>
 {
-    fn from(err: ConsignError) -> Self { Self::InvalidInput(err) }
+    fn from(err: ConsignError) -> Self {
+        Self::InvalidInput(err)
+    }
 }
 
 impl<S: StashProvider, H: StateProvider, P: IndexProvider> From<MergeRevealError>
     for StockError<S, H, P, ConsignError>
 {
-    fn from(err: MergeRevealError) -> Self { Self::InvalidInput(err.into()) }
+    fn from(err: MergeRevealError) -> Self {
+        Self::InvalidInput(err.into())
+    }
 }
 
 impl<S: StashProvider, H: StateProvider, P: IndexProvider> From<RevealError>
     for StockError<S, H, P, ConsignError>
 {
-    fn from(err: RevealError) -> Self { Self::InvalidInput(err.into()) }
+    fn from(err: RevealError) -> Self {
+        Self::InvalidInput(err.into())
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Display, Error, From)]
@@ -228,13 +234,17 @@ pub enum ComposeError {
 impl<S: StashProvider, H: StateProvider, P: IndexProvider> From<ComposeError>
     for StockError<S, H, P, ComposeError>
 {
-    fn from(err: ComposeError) -> Self { Self::InvalidInput(err) }
+    fn from(err: ComposeError) -> Self {
+        Self::InvalidInput(err)
+    }
 }
 
 impl<S: StashProvider, H: StateProvider, P: IndexProvider> From<BuilderError>
     for StockError<S, H, P, ComposeError>
 {
-    fn from(err: BuilderError) -> Self { Self::InvalidInput(err.into()) }
+    fn from(err: BuilderError) -> Self {
+        Self::InvalidInput(err.into())
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Display, Error, From)]
@@ -247,7 +257,9 @@ pub enum FasciaError {
 impl<S: StashProvider, H: StateProvider, P: IndexProvider> From<FasciaError>
     for StockError<S, H, P, FasciaError>
 {
-    fn from(err: FasciaError) -> Self { Self::InvalidInput(err) }
+    fn from(err: FasciaError) -> Self {
+        Self::InvalidInput(err)
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Display, Error, From)]
@@ -261,7 +273,9 @@ pub enum ContractIfaceError {
 impl<S: StashProvider, H: StateProvider, P: IndexProvider> From<ContractIfaceError>
     for StockError<S, H, P, ContractIfaceError>
 {
-    fn from(err: ContractIfaceError) -> Self { Self::InvalidInput(err) }
+    fn from(err: ContractIfaceError) -> Self {
+        Self::InvalidInput(err)
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Display, Error, From)]
@@ -303,19 +317,29 @@ macro_rules! stock_err_conv {
 }
 
 impl From<Infallible> for InputError {
-    fn from(_: Infallible) -> Self { unreachable!() }
+    fn from(_: Infallible) -> Self {
+        unreachable!()
+    }
 }
 impl From<Infallible> for ComposeError {
-    fn from(_: Infallible) -> Self { unreachable!() }
+    fn from(_: Infallible) -> Self {
+        unreachable!()
+    }
 }
 impl From<Infallible> for ConsignError {
-    fn from(_: Infallible) -> Self { unreachable!() }
+    fn from(_: Infallible) -> Self {
+        unreachable!()
+    }
 }
 impl From<Infallible> for FasciaError {
-    fn from(_: Infallible) -> Self { unreachable!() }
+    fn from(_: Infallible) -> Self {
+        unreachable!()
+    }
 }
 impl From<Infallible> for ContractIfaceError {
-    fn from(_: Infallible) -> Self { unreachable!() }
+    fn from(_: Infallible) -> Self {
+        unreachable!()
+    }
 }
 
 stock_err_conv!(Infallible, ComposeError);
@@ -367,11 +391,17 @@ impl<S: StashProvider, H: StateProvider, P: IndexProvider> Stock<S, H, P> {
     }
 
     #[doc(hidden)]
-    pub fn as_stash_provider(&self) -> &S { self.stash.as_provider() }
+    pub fn as_stash_provider(&self) -> &S {
+        self.stash.as_provider()
+    }
     #[doc(hidden)]
-    pub fn as_state_provider(&self) -> &H { &self.state }
+    pub fn as_state_provider(&self) -> &H {
+        &self.state
+    }
     #[doc(hidden)]
-    pub fn as_index_provider(&self) -> &P { self.index.as_provider() }
+    pub fn as_index_provider(&self) -> &P {
+        self.index.as_provider()
+    }
 
     pub fn ifaces(
         &self,
@@ -626,7 +656,12 @@ impl<S: StashProvider, H: StateProvider, P: IndexProvider> Stock<S, H, P> {
                 for index in 0..typed_assignments.len_u16() {
                     let seal = typed_assignments.to_confidential_seals()[index as usize];
                     if secret_seals.contains(&seal) {
-                        terminals.insert(bundle_id, Terminal::new(seal.map(TerminalSeal::from)));
+                        terminals
+                            .entry(bundle_id)
+                            .or_insert(Terminal::new(seal.map(TerminalSeal::from)))
+                            .seals
+                            .push(seal.map(TerminalSeal::from))
+                            .map_err(|_| ConsignError::TooManyTerminals)?;
                     } else if opout.no == index && opout.ty == *type_id {
                         if let Some(seal) = typed_assignments
                             .revealed_seal_at(index)


### PR DESCRIPTION
describe:
When building the consignment file, if multiple seals exist, the previous ones will be overwritten.

The main change is only one line, other changes are automatically formatted by rustfmt.