### PR TITLE
Support custom close methods in vout-based invoices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,8 +142,7 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 [[package]]
 name = "baid64"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5e666513565d0a35116973541fbcb35700619316e1865cb27c7dba5de98668"
+source = "git+https://github.com/UBIDECO/rust-baid64#23b3dd47058cd5d1a338b6dbf48cefb5d1441d59"
 dependencies = [
  "amplify",
  "base64",
@@ -173,10 +172,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
-name = "bitcoin-internals"
-version = "0.2.0"
+name = "bitcoin-io"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+checksum = "340e09e8399c7bd8912f495af6aa58bea0c9214773417ffaa8f6460f93aaee56"
 
 [[package]]
 name = "bitcoin-private"
@@ -186,11 +185,11 @@ checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
- "bitcoin-internals",
+ "bitcoin-io",
  "hex-conservative",
 ]
 
@@ -279,9 +278,8 @@ dependencies = [
 
 [[package]]
 name = "bp-invoice"
-version = "0.11.0-beta.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ee0387fa924bd002b51713c42daf3cb7c3b669509523607445a99c90491788"
+version = "0.11.0-beta.6"
+source = "git+https://github.com/BP-WG/bp-std#f4b1861fd809ae28d364a9e79162ec4294f9de74"
 dependencies = [
  "amplify",
  "bech32",
@@ -494,9 +492,12 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hex-conservative"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "iana-time-zone"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,7 @@ wasm-bindgen-test = "0.3"
 
 [package.metadata.docs.rs]
 features = ["all"]
+
+[patch.crates-io]
+baid64 = { git = "https://github.com/UBIDECO/rust-baid64" }
+bp-invoice = { git = "https://github.com/BP-WG/bp-std" }

--- a/invoice/src/builder.rs
+++ b/invoice/src/builder.rs
@@ -25,7 +25,7 @@ use rgb::ContractId;
 use strict_encoding::{FieldName, TypeName};
 
 use crate::invoice::{Beneficiary, InvoiceState, RgbInvoice, RgbTransport, XChainNet};
-use crate::{Allocation, CoinAmount, NonFungible, Precision, TransportParseError};
+use crate::{Allocation, Amount, CoinAmount, NonFungible, Precision, TransportParseError};
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct RgbInvoiceBuilder(RgbInvoice);
@@ -75,6 +75,11 @@ impl RgbInvoiceBuilder {
 
     pub fn set_assignment(mut self, name: impl Into<FieldName>) -> Self {
         self.0.assignment = Some(name.into());
+        self
+    }
+
+    pub fn set_amount_raw(mut self, amount: impl Into<Amount>) -> Self {
+        self.0.owned_state = InvoiceState::Amount(amount.into());
         self
     }
 

--- a/invoice/src/lib.rs
+++ b/invoice/src/lib.rs
@@ -43,7 +43,8 @@ pub use data::{Allocation, NonFungible, OwnedFraction, TokenIndex};
 pub use parse::{InvoiceParseError, TransportParseError};
 
 pub use crate::invoice::{
-    Beneficiary, ChainNet, InvoiceState, RgbInvoice, RgbTransport, XChainNet,
+    Beneficiary, ChainNet, InvoiceState, Pay2Vout, Pay2VoutError, RgbInvoice, RgbTransport,
+    XChainNet,
 };
 
 pub const LIB_NAME_RGB_CONTRACT: &str = "RGBContract";

--- a/src/persistence/stock.rs
+++ b/src/persistence/stock.rs
@@ -871,14 +871,11 @@ impl<S: StashProvider, H: StateProvider, P: IndexProvider> Stock<S, H, P> {
             (Beneficiary::BlindedSeal(seal), _) => {
                 BuilderSeal::Concealed(XChain::with(layer1, seal))
             }
-            (Beneficiary::WitnessVout(_), Some(vout)) => BuilderSeal::Revealed(XChain::with(
-                layer1,
-                GraphSeal::with_blinded_vout(
-                    method,
-                    vout,
-                    seal_blinder(contract_id, assignment_id),
-                ),
-            )),
+            (Beneficiary::WitnessVout(payload), Some(vout)) => {
+                let blinding = seal_blinder(contract_id, assignment_id);
+                let seal = GraphSeal::with_blinded_vout(payload.method, vout, blinding);
+                BuilderSeal::Revealed(XChain::with(layer1, seal))
+            }
             (Beneficiary::WitnessVout(_), None) => {
                 return Err(ComposeError::NoBeneficiaryOutput.into());
             }


### PR DESCRIPTION
Closes #198 and #119

I decided to address this two issues simultaneously, since it is impossible to reliable parse chunked variable-length strings; thus, in order to get chunking I had to switch to Base64 and fixed-length strings. Since we had to move from bitcoin address format with that, I used the approach as a base to add closing method in a compact form (one byte).