### PR TITLE
check ifaceid, bundleid in consignment

### DIFF
--- a/src/containers/consignment.rs
+++ b/src/containers/consignment.rs
@@ -366,16 +366,13 @@ impl<const TRANSFER: bool> Consignment<TRANSFER> {
         }
 
         // check bundle ids listed in terminals are present in the consignment
-        let bundle_ids = index.bundle_ids().collect::<BTreeSet<_>>();
-        for (bundle_id, _) in self.terminals.iter() {
-            if !bundle_ids.contains(bundle_id) {
+        for bundle_id in self.terminals.keys() {
+            if !index.bundle_ids().any(|id| id == *bundle_id) {
                 status.add_warning(Warning::Custom(s!(
-                    "bundle ids listed in terminals doesn't present in the consignment"
+                    "terminal bundle id {bundle_id} is not present in the consignment"
                 )));
             }
         }
-        // TODO: check that interface ids match implementations
-        // TODO: check bundle ids listed in terminals are present in the consignment
         // TODO: check attach ids from data containers are present in operations
         // TODO: validate sigs and remove untrusted
 

--- a/src/containers/consignment.rs
+++ b/src/containers/consignment.rs
@@ -359,8 +359,11 @@ impl<const TRANSFER: bool> Consignment<TRANSFER> {
         // check ifaceid match implementation
         for (iface, iimpl) in self.ifaces.iter() {
             if iface.iface_id() != iimpl.iface_id {
-                status.add_warning(Warning::Custom(s!(
-                    "interface ids doesn't match implementations"
+                status.add_warning(Warning::Custom(format!(
+                    "implementation {} targets different interface {} than expected {}",
+                    iimpl.impl_id(),
+                    iimpl.iface_id,
+                    iface.iface_id()
                 )));
             }
         }
@@ -368,7 +371,7 @@ impl<const TRANSFER: bool> Consignment<TRANSFER> {
         // check bundle ids listed in terminals are present in the consignment
         for bundle_id in self.terminals.keys() {
             if !index.bundle_ids().any(|id| id == *bundle_id) {
-                status.add_warning(Warning::Custom(s!(
+                status.add_warning(Warning::Custom(format!(
                     "terminal bundle id {bundle_id} is not present in the consignment"
                 )));
             }


### PR DESCRIPTION
Description: for this pull request,
1.check that interface ids match implementations(check iface id matches iface id presents in iimpl)
2.check bundle ids listed in terminals are present in the consignment(get bundle ids from indexconsignment, then check if the bundle id set contains the bundle id in the terminals)
Question: about the `check attach ids from data containers are present in operations`
I don't understand it, should we check whether the attach id from the consignment is equal to the opid present in the operations?(I mean check if the attach id is equal to the opid? If not, where do the operations come from?)
Or should we check the own state from the state transition, then check the attach id in the revealed attach state is equal to the attach id in the consignment?