### PR TITLE
add rights, attachment operations

### DIFF
--- a/src/interface/contract.rs
+++ b/src/interface/contract.rs
@@ -443,4 +443,38 @@ impl ContractIface {
             witness_filter,
         ))
     }
+
+    pub fn rights_ops<C: StateChange<State = VoidState>>(
+        &self,
+        name: impl Into<FieldName>,
+        witness_filter: impl WitnessFilter + Copy,
+        outpoint_filter: impl OutpointFilter + Copy,
+    ) -> Result<HashMap<XWitnessId, IfaceOp<C>>, ContractError> {
+        Ok(self.operations(
+            self.state
+                .rights()
+                .iter()
+                .cloned()
+                .map(OutputAssignment::transmute),
+            self.rights(name, outpoint_filter)?,
+            witness_filter,
+        ))
+    }
+
+    pub fn attachment_ops<C: StateChange<State = AttachedState>>(
+        &self,
+        name: impl Into<FieldName>,
+        witness_filter: impl WitnessFilter + Copy,
+        outpoint_filter: impl OutpointFilter + Copy,
+    ) -> Result<HashMap<XWitnessId, IfaceOp<C>>, ContractError> {
+        Ok(self.operations(
+            self.state
+                .attach()
+                .iter()
+                .cloned()
+                .map(OutputAssignment::transmute),
+            self.attachments(name, outpoint_filter)?,
+            witness_filter,
+        ))
+    }
 }


### PR DESCRIPTION
Description: 

now, there are `fungible_ops`, and `data_ops` related to `FungibleAllocation`, and `DataAllocation`, so I think we can also have `rights_ops`, `attachment_ops` related to `RightsAllocation`, `AttachAllocation`.

1. add `rights_ops` interface
2. add `attachment_ops` interface