### PR TITLE
add interface for contract info

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -19,13 +19,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fmt::{self, Debug, Display, Formatter, Write};
 use std::str::FromStr;
 
 use amplify::confinement::TinyOrdSet;
 use chrono::{DateTime, TimeZone, Utc};
 use rgb::{AltLayer1Set, ContractId, Genesis, Identity, Operation, SchemaId};
+use rgbcore::AltLayer1;
 use strict_encoding::stl::{AlphaCapsLodash, AlphaNumLodash};
 use strict_encoding::{FieldName, RString, StrictDeserialize, StrictSerialize, TypeName};
 
@@ -299,6 +300,21 @@ impl ContractInfo {
             alt_layers1: genesis.alt_layers1.clone(),
         }
     }
+
+    // get contract schema id in string format
+    pub fn schema_id(&self) -> String { self.schema_id.to_string() }
+
+    // get contract issue identity in string format
+    pub fn issuer_identity(&self) -> String { self.issuer.to_string() }
+
+    // get contract issue datetime
+    pub fn issue_datetime(&self) -> DateTime<Utc> { self.issued_at }
+
+    // is contract on testnet
+    pub fn is_testnet(&self) -> bool { self.testnet }
+
+    // get contract alt layer set
+    pub fn alt_layer_set(&self) -> BTreeSet<AltLayer1> { self.alt_layers1.to_inner() }
 }
 
 impl Display for ContractInfo {

--- a/src/interface/contract.rs
+++ b/src/interface/contract.rs
@@ -19,15 +19,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use amplify::confinement::{SmallOrdSet, SmallVec};
+use chrono::{DateTime, Utc};
 use invoice::{Allocation, Amount};
 use rgb::{
     AssignmentWitness, AttachId, ContractId, ContractState, DataState, KnownState, MediaType, OpId,
     OutputAssignment, RevealedAttach, RevealedData, RevealedValue, VoidState, XOutpoint,
     XOutputSeal, XWitnessId,
 };
+use rgbcore::AltLayer1;
 use strict_encoding::{FieldName, StrictDecode, StrictDumb, StrictEncode};
 use strict_types::typify::TypedVal;
 use strict_types::{decode, StrictVal, TypeSystem};
@@ -477,4 +479,18 @@ impl ContractIface {
             witness_filter,
         ))
     }
+    // get contract schema id by contract iface
+    pub fn contract_schema_id(&self) -> String { self.info.schema_id() }
+
+    // get contract issuer identity by contract iface
+    pub fn contract_issuer_identity(&self) -> String { self.info.issuer_identity() }
+
+    // get contract issue datetime by contract iface
+    pub fn contract_issue_datetime(&self) -> DateTime<Utc> { self.info.issue_datetime() }
+
+    // is contract on testnet by contract iface
+    pub fn contract_is_testnet(&self) -> bool { self.info.is_testnet() }
+
+    // get contract alt layer set by contract iface
+    pub fn contract_alt_layer_set(&self) -> BTreeSet<AltLayer1> { self.info.alt_layer_set() }
 }


### PR DESCRIPTION
Description: there is an `info: ContractInfo` in the ContractIface, in this pull request, the following contract info interfaces are added to get related contract information.

1. Schema ID in string format
2. issue identity in string format
3. issue date time 
4. is on the testnet or not
5. alt layer set

So the developers can directly call the related contract interface to get contract info(such as `self.info.issuer_identity()` to get the contract issuer identity in string format).
