### PR TITLE
Check attach

### DIFF
--- a/src/containers/consignment.rs
+++ b/src/containers/consignment.rs
@@ -384,11 +384,7 @@ impl<const TRANSFER: bool> Consignment<TRANSFER> {
                 .known_transitions
                 .values()
                 .for_each(|transition| {
-                    transition.assignments.values().for_each(|assign| {
-                        assign.as_attachment().iter().for_each(|item| {
-                            let state = item
-                                .as_revealed_state()
-                                .expect("get revealed attached state failed");
+                    transition.assignments.values().filter_map(|assign| assign.as_attachment().and_then(Attach::as_revealed_state)).for_each(|assign| {
                             if !self.attachments.keys().any(|&id| id == state.id) {
                                 status.add_warning(Warning::Custom(format!(
                                     "attach id from data containers {:?} is not present in the \

--- a/src/containers/consignment.rs
+++ b/src/containers/consignment.rs
@@ -376,25 +376,31 @@ impl<const TRANSFER: bool> Consignment<TRANSFER> {
                 )));
             }
         }
+        index.bundle_ids().for_each(|bundle_id| {
+            let transition_bundle = index
+                .bundle(bundle_id)
+                .expect("index transition bundle failed");
+            transition_bundle
+                .known_transitions
+                .values()
+                .for_each(|transition| {
+                    transition.assignments.values().for_each(|assign| {
+                        assign.as_attachment().iter().for_each(|item| {
+                            let state = item
+                                .as_revealed_state()
+                                .expect("get revealed attached state failed");
+                            if !self.attachments.keys().any(|&id| id == state.id) {
+                                status.add_warning(Warning::Custom(format!(
+                                    "attach id from data containers {:?} is not present in the \
+                                     consignment",
+                                    state.id
+                                )));
+                            }
+                        })
+                    })
+                })
+        });
 
-        for bundle in self.bundles.iter() {
-            for transition_bundle in bundle.bundles() {
-                for transition in transition_bundle.known_transitions.values() {
-                    for assign in transition.assignments.values() {
-                        assign.as_attachment()
-                            .iter()
-                            .for_each(|item| {
-                                let state = item.as_revealed_state().unwrap();
-                                if !self.attachments.keys().any(|&id| id == state.id ) {
-                                    status.add_warning(Warning::Custom(format!(
-                                        "attach id {:?} is not present in the consignment"
-                                    , state.id)));
-                                }
-                            })
-                    }
-                }
-            }
-        }
         // TODO: check attach ids from data containers are present in operations
         // TODO: validate sigs and remove untrusted
 

--- a/src/containers/consignment.rs
+++ b/src/containers/consignment.rs
@@ -376,6 +376,25 @@ impl<const TRANSFER: bool> Consignment<TRANSFER> {
                 )));
             }
         }
+
+        for bundle in self.bundles.iter() {
+            for transition_bundle in bundle.bundles() {
+                for transition in transition_bundle.known_transitions.values() {
+                    for assign in transition.assignments.values() {
+                        assign.as_attachment()
+                            .iter()
+                            .for_each(|item| {
+                                let state = item.as_revealed_state().unwrap();
+                                if !self.attachments.keys().any(|&id| id == state.id ) {
+                                    status.add_warning(Warning::Custom(format!(
+                                        "attach id {:?} is not present in the consignment"
+                                    , state.id)));
+                                }
+                            })
+                    }
+                }
+            }
+        }
         // TODO: check attach ids from data containers are present in operations
         // TODO: validate sigs and remove untrusted
 


### PR DESCRIPTION
Description: check attached ids from data containers are present in the consignment.

1. iter bundle ids from index consignment
2. index transition bundle by bundle id
3. for each transition bundle, get all transitions
4. for each transition, get all assignments, and then get the revealed attach state by `as_attachment()`
5. finally, check attached id from the consignment is equal to attached id from the reveal attach state(also, from the operation transition attach state).

I'm not sure if the logic I implemented is correct.