### PR TITLE
unreachable to ord for amount

### DIFF
--- a/src/interface/contract.rs
+++ b/src/interface/contract.rs
@@ -168,9 +168,9 @@ impl StateChange for AmountChange {
             AmountChange::Inc(pos) => AmountChange::Inc(*pos + add),
             AmountChange::Zero => AmountChange::Inc(add),
             AmountChange::Dec(neg) => match add.cmp(neg) {
-                Ordering::Greater => AmountChange::Dec(*neg - add),
+                Ordering::Less => AmountChange::Dec(*neg - add),
                 Ordering::Equal => AmountChange::Zero,
-                Ordering::Less => AmountChange::Inc(add - *neg),
+                Ordering::Greater => AmountChange::Inc(add - *neg),
             },
         };
     }

--- a/src/interface/contract.rs
+++ b/src/interface/contract.rs
@@ -19,6 +19,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 
 use amplify::confinement::{SmallOrdSet, SmallVec};
@@ -154,10 +155,11 @@ impl StateChange for AmountChange {
         *self = match self {
             AmountChange::Dec(neg) => AmountChange::Dec(*neg + sub),
             AmountChange::Zero => AmountChange::Dec(sub),
-            AmountChange::Inc(pos) if *pos > sub => AmountChange::Inc(*pos - sub),
-            AmountChange::Inc(pos) if *pos == sub => AmountChange::Zero,
-            AmountChange::Inc(pos) if *pos < sub => AmountChange::Dec(sub - *pos),
-            AmountChange::Inc(_) => unreachable!(),
+            AmountChange::Inc(pos) => match sub.cmp(pos) {
+                Ordering::Less => AmountChange::Inc(*pos - sub),
+                Ordering::Equal => AmountChange::Zero,
+                Ordering::Greater => AmountChange::Dec(sub - *pos),
+            },
         };
     }
 
@@ -165,10 +167,11 @@ impl StateChange for AmountChange {
         *self = match self {
             AmountChange::Inc(pos) => AmountChange::Inc(*pos + add),
             AmountChange::Zero => AmountChange::Inc(add),
-            AmountChange::Dec(neg) if *neg > add => AmountChange::Dec(*neg - add),
-            AmountChange::Dec(neg) if *neg == add => AmountChange::Zero,
-            AmountChange::Dec(neg) if *neg < add => AmountChange::Inc(add - *neg),
-            AmountChange::Dec(_) => unreachable!(),
+            AmountChange::Dec(neg) => match add.cmp(neg) {
+                Ordering::Greater => AmountChange::Dec(*neg - add),
+                Ordering::Equal => AmountChange::Zero,
+                Ordering::Less => AmountChange::Inc(add - *neg),
+            },
         };
     }
 }


### PR DESCRIPTION
Background:

Based on https://github.com/RGB-WG/rgb-std/pull/227, there is also an `unreachable` in the rgb20 amount, so I think maybe we can change to the `Ord` in order to get rid of unreachable.

Description:

remove the `unreachable` in the rgb20 amount state change, then use the `Ord`. Similar to the rgb21 owed fraction state change.