### PR TITLE
Collect supplyment features in consign

### DIFF
--- a/src/persistence/memory.rs
+++ b/src/persistence/memory.rs
@@ -173,6 +173,10 @@ impl StashReadProvider for MemStash {
             .into_iter())
     }
 
+    fn get_sigs(&self, content_id: &ContentId) -> Result<Option<&ContentSigs>, Self::Error> {
+        Ok(self.sigs.get(&content_id))
+    }
+
     fn geneses(&self) -> Result<impl Iterator<Item = &Genesis>, Self::Error> {
         Ok(self.geneses.values())
     }

--- a/src/persistence/memory.rs
+++ b/src/persistence/memory.rs
@@ -174,7 +174,7 @@ impl StashReadProvider for MemStash {
     }
 
     fn get_sigs(&self, content_id: &ContentId) -> Result<Option<&ContentSigs>, Self::Error> {
-        Ok(self.sigs.get(&content_id))
+        Ok(self.sigs.get(content_id))
     }
 
     fn geneses(&self) -> Result<impl Iterator<Item = &Genesis>, Self::Error> {

--- a/src/persistence/memory.rs
+++ b/src/persistence/memory.rs
@@ -173,7 +173,7 @@ impl StashReadProvider for MemStash {
             .into_iter())
     }
 
-    fn get_sigs(&self, content_id: &ContentId) -> Result<Option<&ContentSigs>, Self::Error> {
+    fn sigs_for(&self, content_id: &ContentId) -> Result<Option<&ContentSigs>, Self::Error> {
         Ok(self.sigs.get(content_id))
     }
 

--- a/src/persistence/stash.rs
+++ b/src/persistence/stash.rs
@@ -39,7 +39,8 @@ use strict_types::typesys::UnknownType;
 use strict_types::TypeSystem;
 
 use crate::containers::{
-    BundledWitness, Consignment, ContentId, ContentRef, ContentSigs, Kit, SealWitness, SigBlob, Supplement, TrustLevel
+    BundledWitness, Consignment, ContentId, ContentRef, ContentSigs, Kit, SealWitness, SigBlob,
+    Supplement, TrustLevel,
 };
 use crate::interface::{
     ContractBuilder, Iface, IfaceClass, IfaceId, IfaceImpl, IfaceRef, TransitionBuilder,

--- a/src/persistence/stash.rs
+++ b/src/persistence/stash.rs
@@ -625,7 +625,7 @@ pub trait StashReadProvider {
         content_ref: ContentRef,
     ) -> Result<impl Iterator<Item = Supplement>, Self::Error>;
 
-    fn get_sigs(&self, content_id: &ContentId) -> Result<Option<&ContentSigs>, Self::Error>;
+    fn sigs_for(&self, content_id: &ContentId) -> Result<Option<&ContentSigs>, Self::Error>;
     fn witness_ids(&self) -> Result<impl Iterator<Item = XWitnessId>, Self::Error>;
     fn bundle_ids(&self) -> Result<impl Iterator<Item = BundleId>, Self::Error>;
     fn bundle(&self, bundle_id: BundleId) -> Result<&TransitionBundle, ProviderError<Self::Error>>;

--- a/src/persistence/stash.rs
+++ b/src/persistence/stash.rs
@@ -39,8 +39,7 @@ use strict_types::typesys::UnknownType;
 use strict_types::TypeSystem;
 
 use crate::containers::{
-    BundledWitness, Consignment, ContentId, ContentRef, Kit, SealWitness, SigBlob, Supplement,
-    TrustLevel,
+    BundledWitness, Consignment, ContentId, ContentRef, ContentSigs, Kit, SealWitness, SigBlob, Supplement, TrustLevel
 };
 use crate::interface::{
     ContractBuilder, Iface, IfaceClass, IfaceId, IfaceImpl, IfaceRef, TransitionBuilder,
@@ -625,6 +624,7 @@ pub trait StashReadProvider {
         content_ref: ContentRef,
     ) -> Result<impl Iterator<Item = Supplement>, Self::Error>;
 
+    fn get_sigs(&self, content_id: &ContentId) -> Result<Option<&ContentSigs>, Self::Error>;
     fn witness_ids(&self) -> Result<impl Iterator<Item = XWitnessId>, Self::Error>;
     fn bundle_ids(&self) -> Result<impl Iterator<Item = BundleId>, Self::Error>;
     fn bundle(&self, bundle_id: BundleId) -> Result<&TransitionBundle, ProviderError<Self::Error>>;


### PR DESCRIPTION

Description:

1. add a `get_sigs` interface for obtaining the content_sig in order to collect signatures. (the reason for adding this interface is that there are `add_supplyment`, and `supplement` interfaces for adding and obtaining the supplement, and then I noticed that there is an `import_sigs` interface, but no method to get content signature by content ID, so I think maybe we need an interface to obtain the content signature)

2. collect supplements.
3. test cases.