### PR TITLE
collect signatures from the stash

### DIFF
--- a/src/persistence/stash.rs
+++ b/src/persistence/stash.rs
@@ -255,6 +255,15 @@ impl<P: StashProvider> Stash<P> {
             .map_err(StashError::ReadProvider)
     }
 
+    pub(super) fn sigs_for(
+        &self,
+        content_id: &ContentId,
+    ) -> Result<Option<&ContentSigs>, StashError<P>> {
+        self.provider
+            .sigs_for(content_id)
+            .map_err(StashError::ReadProvider)
+    }
+
     pub(super) fn supplement(
         &self,
         content_ref: ContentRef,


### PR DESCRIPTION

Description:

1. Add `sigs_for` in the stash reader provider
2. Collect genesis, scheme, iface, and iimpl signatures from the stash provider

Questions: I don't understand the following `TODO`
1. Conceal everything we do not need. (conceal seal, transition, and state?)
2. Add known sigs to the consignment. (What's the difference from the `collect signatures from the stash`?)

And the `know sigs`, do you mean the content signatures from the stash or the signatures from the disclosure? (In the Disclosure, there is `PublicKey, Signature` Key-Value map).