### PR TITLE
persistence: allow replacing witnesses for consumed fascia

### DIFF
--- a/src/persistence/memory.rs
+++ b/src/persistence/memory.rs
@@ -676,18 +676,21 @@ impl IndexWriteProvider for MemIndex {
         bundle_id: BundleId,
         witness_id: XWitnessId,
         contract_id: ContractId,
+        replace_witness: bool,
     ) -> Result<bool, IndexWriteError<Self::Error>> {
-        if let Some(alt) = self
-            .bundle_witness_index
-            .get(&bundle_id)
-            .filter(|alt| *alt != &witness_id)
-        {
-            return Err(IndexInconsistency::DistinctBundleWitness {
-                bundle_id,
-                present: *alt,
-                expected: witness_id,
+        if !replace_witness {
+            if let Some(alt) = self
+                .bundle_witness_index
+                .get(&bundle_id)
+                .filter(|alt| *alt != &witness_id)
+            {
+                return Err(IndexInconsistency::DistinctBundleWitness {
+                    bundle_id,
+                    present: *alt,
+                    expected: witness_id,
+                }
+                .into());
             }
-            .into());
         }
         if let Some(alt) = self
             .bundle_contract_index

--- a/src/persistence/stock.rs
+++ b/src/persistence/stock.rs
@@ -1218,9 +1218,17 @@ impl<S: StashProvider, H: StateProvider, P: IndexProvider> Stock<S, H, P> {
     ///
     /// Must be called before the consignment is created, when witness
     /// transaction is not yet mined.
+    ///
+    /// # Arguments
+    ///
+    /// - `replace_witness` defines whether a bundle id, if present, must be
+    ///   associated with newer witness. The only use case for that is when
+    ///   consuming fascia for lightning channel transactions on channel
+    ///   updates.
     pub fn consume_fascia(
         &mut self,
         fascia: Fascia,
+        replace_witness: bool,
     ) -> Result<(), StockError<S, H, P, FasciaError>> {
         self.store_transaction(move |stash, state, index| {
             let witness_id = fascia.witness_id();
@@ -1238,7 +1246,7 @@ impl<S: StashProvider, H: StateProvider, P: IndexProvider> Stock<S, H, P> {
                     return Err(FasciaError::InvalidBundle(contract_id, bundle.bundle_id()).into());
                 }
 
-                index.index_bundle(contract_id, &bundle, witness_id)?;
+                index.index_bundle(contract_id, &bundle, witness_id, replace_witness)?;
 
                 state.update_state::<DumbResolver>(contract_id, |history| {
                     for transition in bundle.known_transitions.values() {


### PR DESCRIPTION
Can be used to address https://github.com/RGB-WG/rgb-std/issues/238

I do believe though that if this approach is used, it won't be possible to use RGB funds from the stock after non-cooperative closing (since the index would point to a non-existing witness transaction).