### PR TITLE
Support spending mixed opret/tapret outputs

### DIFF
--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -51,7 +51,8 @@ pub use file::{FileContent, LoadError, UniversalFile};
 pub use indexed::IndexedConsignment;
 pub use kit::{Kit, KitId, ValidKit};
 pub use partials::{
-    Batch, BundleDichotomy, CloseMethodSet, Fascia, TransitionInfo, TransitionInfoError,
+    Batch, BundleDichotomy, CloseMethodSet, Dichotomy, Fascia, TransitionDichotomy, TransitionInfo,
+    TransitionInfoError,
 };
 pub use seal::{BuilderSeal, VoutSeal};
 pub use suppl::{

--- a/src/containers/partials.rs
+++ b/src/containers/partials.rs
@@ -219,7 +219,9 @@ impl IntoIterator for Batch {
 impl Batch {
     pub fn close_method_set(&self) -> CloseMethodSet {
         let mut methods = CloseMethodSet::from(self.main.first.method);
-        self.main.second.as_ref().map(|info| methods |= info.method);
+        if let Some(info) = &self.main.second {
+            methods |= info.method;
+        }
         self.blanks.iter().for_each(|i| methods |= i.first.method);
         self.blanks
             .iter()
@@ -230,15 +232,14 @@ impl Batch {
 
     pub fn set_priority(&mut self, priority: u8) {
         self.main.first.transition.nonce = priority;
-        self.main
-            .second
-            .as_mut()
-            .map(|info| info.transition.nonce = priority);
+        if let Some(info) = &mut self.main.second {
+            info.transition.nonce = priority;
+        }
         for info in &mut self.blanks {
             info.first.transition.nonce = priority;
-            info.second
-                .as_mut()
-                .map(|info| info.transition.nonce = priority);
+            if let Some(info) = &mut info.second {
+                info.transition.nonce = priority;
+            }
         }
     }
 }

--- a/src/containers/partials.rs
+++ b/src/containers/partials.rs
@@ -259,6 +259,16 @@ pub struct Dichotomy<T: StrictDumb + StrictEncode + StrictDecode> {
     pub second: Option<T>,
 }
 
+impl<T: StrictDumb + StrictEncode + StrictDecode> FromIterator<T> for Dichotomy<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut iter = iter.into_iter();
+        let first = iter.next().expect("iterator must have at least one item");
+        let second = iter.next();
+        assert!(iter.next().is_none(), "iterator must have at most two items");
+        Self { first, second }
+    }
+}
+
 impl<T: StrictDumb + StrictEncode + StrictDecode> IntoIterator for Dichotomy<T> {
     type Item = T;
     type IntoIter = vec::IntoIter<T>;

--- a/src/interface/builder.rs
+++ b/src/interface/builder.rs
@@ -797,6 +797,8 @@ impl TransitionBuilder {
         Ok(self)
     }
 
+    pub fn has_inputs(&self) -> bool { !self.inputs.is_empty() }
+
     pub fn complete_transition(self) -> Result<Transition, BuilderError> {
         let (_, _, _, global, assignments, _, _) = self.builder.complete(Some(&self.inputs));
 


### PR DESCRIPTION
Closes #246

If PSBT inputs contain single-use seals of different types (opret and taproot) spent by the same wallet, we need to create two state transitions - one for tapret and one for opret. The main state transition is the one which matches the type of the wallet descriptor; the other state transition will just transform invalid seal type into correct one allocated to the change output. We also have to construct blank transitions of both types, as needed.

If PSBT is multi-party with wallets of different seal types, this situation doesn't happen since each wallet works and updates PSBT independently and their state transitions does not cross.