### PR TITLE
Make v0.12 APIs more consistent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "hypersonic"
 version = "0.12.0-beta.5"
-source = "git+https://github.com/AluVM/sonic?branch=refactor#140cf7e65c748cc125244749e7546e5e77cc1f4d"
+source = "git+https://github.com/AluVM/sonic?branch=master#530d3cd06997210ac55619d424fc4640546e8adf"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1046,7 +1046,7 @@ dependencies = [
 [[package]]
 name = "sonic-api"
 version = "0.12.0-beta.5"
-source = "git+https://github.com/AluVM/sonic?branch=refactor#140cf7e65c748cc125244749e7546e5e77cc1f4d"
+source = "git+https://github.com/AluVM/sonic?branch=master#530d3cd06997210ac55619d424fc4640546e8adf"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1065,7 +1065,7 @@ dependencies = [
 [[package]]
 name = "sonic-callreq"
 version = "0.12.0-beta.5"
-source = "git+https://github.com/AluVM/sonic?branch=refactor#140cf7e65c748cc125244749e7546e5e77cc1f4d"
+source = "git+https://github.com/AluVM/sonic?branch=master#530d3cd06997210ac55619d424fc4640546e8adf"
 dependencies = [
  "amplify",
  "baid64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,12 +139,15 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 [[package]]
 name = "aora"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20d908b443b82063d02543282f046fa7ac5e05abc6a7c9958313f0fa4da5881"
+source = "git+https://github.com/rust-amplify/aora?branch=master#1217885510d7f882d949d8832152684a0d70a744"
 dependencies = [
+ "amplify",
  "binfile",
+ "getrandom",
  "indexmap",
+ "log",
  "strict_encoding",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -372,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -382,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -585,7 +588,7 @@ dependencies = [
 [[package]]
 name = "hypersonic"
 version = "0.12.0-beta.5"
-source = "git+https://github.com/AluVM/sonic?branch=master#921f34ffc65d21bc42b0a1034b9d9a3b24f472ed"
+source = "git+https://github.com/AluVM/sonic?branch=refactor#140cf7e65c748cc125244749e7546e5e77cc1f4d"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1043,7 +1046,7 @@ dependencies = [
 [[package]]
 name = "sonic-api"
 version = "0.12.0-beta.5"
-source = "git+https://github.com/AluVM/sonic?branch=master#921f34ffc65d21bc42b0a1034b9d9a3b24f472ed"
+source = "git+https://github.com/AluVM/sonic?branch=refactor#140cf7e65c748cc125244749e7546e5e77cc1f4d"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1062,7 +1065,7 @@ dependencies = [
 [[package]]
 name = "sonic-callreq"
 version = "0.12.0-beta.5"
-source = "git+https://github.com/AluVM/sonic?branch=master#921f34ffc65d21bc42b0a1034b9d9a3b24f472ed"
+source = "git+https://github.com/AluVM/sonic?branch=refactor#140cf7e65c748cc125244749e7546e5e77cc1f4d"
 dependencies = [
  "amplify",
  "baid64",
@@ -1228,7 +1231,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 [[package]]
 name = "ultrasonic"
 version = "0.12.0-beta.5"
-source = "git+https://github.com/AluVM/ultrasonic?branch=master#bf3a155acf9804b21a3178e5602927f892e3b38c"
+source = "git+https://github.com/AluVM/ultrasonic?branch=master#f08a6749bb6c97837130dce07ae04c73e92a36c9"
 dependencies = [
  "amplify",
  "baid64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ aora = { git = "https://github.com/rust-amplify/aora", branch = "master" }
 aluvm = { git = "https://github.com/AluVM/aluvm", branch = "master" }
 zk-aluvm = { git = "https://github.com/AluVM/zk-aluvm", branch = "master" }
 ultrasonic = { git = "https://github.com/AluVM/ultrasonic", branch = "master" }
-sonic-api = { git = "https://github.com/AluVM/sonic", branch = "refactor" }
-sonic-callreq = { git = "https://github.com/AluVM/sonic", branch = "refactor" }
-hypersonic = { git = "https://github.com/AluVM/sonic", branch = "refactor" }
+sonic-api = { git = "https://github.com/AluVM/sonic", branch = "master" }
+sonic-callreq = { git = "https://github.com/AluVM/sonic", branch = "master" }
+hypersonic = { git = "https://github.com/AluVM/sonic", branch = "master" }
 rgb-core = { git = "https://github.com/RGB-WG/rgb-core", branch = "v0.12" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,10 +108,11 @@ wasm-bindgen-test = "0.3"
 features = ["all"]
 
 [patch.crates-io]
+aora = { git = "https://github.com/rust-amplify/aora", branch = "master" }
 aluvm = { git = "https://github.com/AluVM/aluvm", branch = "master" }
 zk-aluvm = { git = "https://github.com/AluVM/zk-aluvm", branch = "master" }
 ultrasonic = { git = "https://github.com/AluVM/ultrasonic", branch = "master" }
-sonic-api = { git = "https://github.com/AluVM/sonic", branch = "master" }
-sonic-callreq = { git = "https://github.com/AluVM/sonic", branch = "master" }
-hypersonic = { git = "https://github.com/AluVM/sonic", branch = "master" }
+sonic-api = { git = "https://github.com/AluVM/sonic", branch = "refactor" }
+sonic-callreq = { git = "https://github.com/AluVM/sonic", branch = "refactor" }
+hypersonic = { git = "https://github.com/AluVM/sonic", branch = "refactor" }
 rgb-core = { git = "https://github.com/RGB-WG/rgb-core", branch = "v0.12" }

--- a/cli/src/dump.rs
+++ b/cli/src/dump.rs
@@ -36,8 +36,8 @@ use commit_verify::ReservedBytes;
 use hypersonic::persistance::StockFs;
 use hypersonic::{Articles, ContractId, Operation};
 use rgb::{
-    FilePile, MoundConsumeError, Pile, PublishedWitness, RgbSeal, RgbSealDef, SealWitness,
-    SingleUseSeal, Stockpile, MAGIC_BYTES_CONSIGNMENT,
+    Contract, FilePile, MoundConsumeError, Pile, PublishedWitness, RgbSeal, RgbSealDef,
+    SealWitness, SingleUseSeal, MAGIC_BYTES_CONSIGNMENT,
 };
 use serde::{Deserialize, Serialize};
 use strict_encoding::{DecodeError, StreamReader, StrictDecode, StrictEncode, StrictReader};
@@ -53,17 +53,17 @@ where
     let dst = dst.as_ref();
     fs::create_dir_all(dst)?;
 
-    print!("Reading contract stockpile from '{}' ... ", src.display());
-    let mut stockpile = Stockpile::<StockFs, FilePile<Seal>>::load_from_path(src.to_path_buf())?;
-    println!("success reading {}", stockpile.contract_id());
+    print!("Reading contract contract from '{}' ... ", src.display());
+    let contract = Contract::<StockFs, FilePile<Seal>>::load_from_path(src.to_path_buf())?;
+    println!("success reading {}", contract.contract_id());
 
     print!("Processing contract articles ... ");
     let out = File::create_new(dst.join("articles.yaml"))?;
-    serde_yaml::to_writer(&out, stockpile.contract().articles())?;
+    serde_yaml::to_writer(&out, contract.articles())?;
     println!("success");
 
     print!("Processing operations ... none found");
-    for (no, (opid, op)) in stockpile.contract().operations().enumerate() {
+    for (no, (opid, op)) in contract.ledger().operations().enumerate() {
         let out = File::create_new(dst.join(format!("{:04}-{opid}.op.yaml", no + 1)))?;
         serde_yaml::to_writer(&out, &op)?;
         print!("\rProcessing operations ... {} processed", no + 1);
@@ -71,7 +71,7 @@ where
     println!();
 
     print!("Processing trace ... none state transitions found");
-    for (no, (opid, st)) in stockpile.contract().trace().enumerate() {
+    for (no, (opid, st)) in contract.ledger().trace().enumerate() {
         let out = File::create_new(dst.join(format!("{:04}-{opid}.st.yaml", no + 1)))?;
         serde_yaml::to_writer(&out, &st)?;
         print!("\rProcessing trace ... {} state transition processed", no + 1);
@@ -80,19 +80,19 @@ where
 
     print!("Processing state ... ");
     let out = File::create_new(dst.join("state.yaml"))?;
-    serde_yaml::to_writer(&out, &stockpile.state())?;
+    serde_yaml::to_writer(&out, &contract.state())?;
     let out = File::create_new(dst.join("state-raw.yaml"))?;
-    serde_yaml::to_writer(&out, &stockpile.contract().state().raw)?;
+    serde_yaml::to_writer(&out, &contract.ledger().state().raw)?;
     let out = File::create_new(dst.join("state-main.yaml"))?;
-    serde_yaml::to_writer(&out, &stockpile.contract().state().main)?;
-    for (name, state) in &stockpile.contract().state().aux {
+    serde_yaml::to_writer(&out, &contract.ledger().state().main)?;
+    for (name, state) in &contract.ledger().state().aux {
         let out = File::create_new(dst.join(format!("state-{name}.yaml")))?;
         serde_yaml::to_writer(&out, state)?;
     }
     println!("success");
 
     print!("Processing anchors ... none found");
-    for (no, (txid, anchor)) in stockpile.pile().hoard().iter().enumerate() {
+    for (no, (txid, anchor)) in contract.pile().hoard().iter().enumerate() {
         let out = File::create_new(dst.join(format!("{txid}.anchor.yaml")))?;
         serde_yaml::to_writer(&out, &anchor)?;
         print!("\rProcessing anchors ... {} processed", no + 1);
@@ -100,7 +100,7 @@ where
     println!();
 
     print!("Processing witness transactions ... none found");
-    for (no, (txid, tx)) in stockpile.pile().cache().iter().enumerate() {
+    for (no, (txid, tx)) in contract.pile().cache().iter().enumerate() {
         let out = File::create_new(dst.join(format!("{txid}.yaml")))?;
         serde_yaml::to_writer(&out, &tx)?;
         print!("\rProcessing witness transactions ... {} processed", no + 1);
@@ -109,7 +109,7 @@ where
 
     print!("Processing seal definitions ... none found");
     let mut seal_count = 0;
-    for (no, (opid, seals)) in stockpile.pile().keep().iter().enumerate() {
+    for (no, (opid, seals)) in contract.pile().keep().iter().enumerate() {
         let out = File::create_new(dst.join(format!("{no:04}-{opid}.seals.yaml")))?;
         serde_yaml::to_writer(&out, &seals)?;
         seal_count += seals.len();
@@ -118,7 +118,7 @@ where
     println!();
 
     print!("Processing index ... ");
-    let index = stockpile.pile().index();
+    let index = contract.pile().index();
     let index = index
         .keys()
         .map(|opid| (opid, index.get(opid).collect::<Vec<_>>()))

--- a/src/info.rs
+++ b/src/info.rs
@@ -42,13 +42,13 @@ impl ContractInfo {
     pub fn new(id: ContractId, articles: &Articles) -> Self {
         Self {
             id,
-            name: articles.contract.meta.name.clone(),
-            issuer: articles.contract.meta.issuer.clone(),
-            timestamp: DateTime::from_timestamp(articles.contract.meta.timestamp, 0)
+            name: articles.issue.meta.name.clone(),
+            issuer: articles.issue.meta.issuer.clone(),
+            timestamp: DateTime::from_timestamp(articles.issue.meta.timestamp, 0)
                 .expect("Invalid timestamp"),
             codex: CodexInfo::new(&articles.schema.codex),
-            consensus: articles.contract.meta.consensus,
-            testnet: articles.contract.meta.testnet,
+            consensus: articles.issue.meta.consensus,
+            testnet: articles.issue.meta.testnet,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ extern crate serde;
 pub extern crate rgb_invoice as invoice;
 
 mod pile;
-mod stockpile;
+mod contract;
 mod mound;
 mod info;
 pub mod popls;
@@ -50,6 +50,9 @@ mod util;
 
 #[cfg(feature = "bitcoin")]
 pub use bp::{Outpoint, Txid};
+pub use contract::{
+    Assignment, ConsumeError, Contract, CreateParams, EitherSeal, ImmutableState, OwnedState,
+};
 pub use hypersonic::*;
 pub use info::ContractInfo;
 #[cfg(feature = "fs")]
@@ -59,7 +62,4 @@ pub use mound::{Excavate, IssueError, Mound, MoundConsumeError, MAGIC_BYTES_CONS
 pub use pile::fs::FilePile;
 pub use pile::{Pile, WitnessStatus};
 pub use rgb::*;
-pub use stockpile::{
-    Assignment, ConsumeError, CreateParams, EitherSeal, ImmutableState, OwnedState, Stockpile,
-};
 pub use util::{ContractRef, InvalidContractRef};

--- a/src/mound.rs
+++ b/src/mound.rs
@@ -286,7 +286,7 @@ pub mod file {
     use strict_encoding::{DeserializeError, StreamWriter, StrictDecode, StrictEncode};
 
     use super::*;
-    use crate::FilePile;
+    use crate::providers::PileFs;
 
     pub struct DirExcavator<Seal: RgbSeal> {
         dir: PathBuf,
@@ -324,7 +324,7 @@ pub mod file {
         }
     }
 
-    impl<Seal: RgbSeal> Excavate<StockFs, FilePile<Seal>> for DirExcavator<Seal>
+    impl<Seal: RgbSeal> Excavate<StockFs, PileFs<Seal>> for DirExcavator<Seal>
     where
         Seal::Client: StrictEncode + StrictDecode,
         Seal::Published: Eq + StrictEncode + StrictDecode,
@@ -342,9 +342,7 @@ pub mod file {
             })
         }
 
-        fn contracts(
-            &self,
-        ) -> impl Iterator<Item = (ContractId, Contract<StockFs, FilePile<Seal>>)> {
+        fn contracts(&self) -> impl Iterator<Item = (ContractId, Contract<StockFs, PileFs<Seal>>)> {
             self.contents(false).filter_map(|(ty, path)| {
                 if ty.is_dir() && path.extension().and_then(OsStr::to_str) == Some("contract") {
                     let contract = Contract::load_from_path(path.clone())
@@ -362,7 +360,7 @@ pub mod file {
         }
     }
 
-    pub type DirMound<Seal> = Mound<StockFs, FilePile<Seal>, DirExcavator<Seal>>;
+    pub type DirMound<Seal> = Mound<StockFs, PileFs<Seal>, DirExcavator<Seal>>;
 
     impl<Seal: RgbSeal> DirMound<Seal>
     where
@@ -391,7 +389,7 @@ pub mod file {
             params: CreateParams<Seal::Definiton>,
         ) -> Result<ContractId, IssueError<io::Error>> {
             let dir = self.persistence.consensus_dir();
-            let pile = FilePile::<Seal>::create_new(params.name.as_str(), &dir)
+            let pile = PileFs::<Seal>::create_new(params.name.as_str(), &dir)
                 .map_err(hypersonic::IssueError::OtherPersistence)?;
             self.issue(params, dir, pile)
         }

--- a/src/pile.rs
+++ b/src/pile.rs
@@ -172,6 +172,7 @@ where <Self::Seal as RgbSeal>::WitnessId: From<[u8; 32]> + Into<[u8; 32]>
 
 #[cfg(feature = "fs")]
 pub mod fs {
+    use std::io;
     use std::marker::PhantomData;
     use std::path::Path;
 
@@ -202,29 +203,20 @@ pub mod fs {
     impl<Seal: RgbSeal> FilePile<Seal>
     where Seal::WitnessId: From<[u8; 32]> + Into<[u8; 32]>
     {
-        pub fn new(name: &str, path: impl AsRef<Path>) -> Self {
+        pub fn create_new(name: &str, path: impl AsRef<Path>) -> io::Result<Self> {
             let mut path = path.as_ref().to_path_buf();
             path.push(name);
             path.set_extension("contract");
 
-            let hoard = FileAoraMap::new(&path, "hoard");
-            let cache = FileAoraMap::new(&path, "cache");
-            let keep = FileAoraMap::new(&path, "keep");
+            let hoard = FileAoraMap::create_new(&path, "hoard")?;
+            let cache = FileAoraMap::create_new(&path, "cache")?;
+            let keep = FileAoraMap::create_new(&path, "keep")?;
 
-            let index_file = path.join("index.dat");
-            let index = FileAoraIndex::create(index_file.clone()).unwrap_or_else(|_| {
-                panic!("unable to create index file '{}'", index_file.display())
-            });
-            let stand_file = path.join("stand.dat");
-            let stand = FileAoraIndex::create(stand_file.clone()).unwrap_or_else(|_| {
-                panic!("unable to create stand file '{}'", stand_file.display())
-            });
-            let mine_file = path.join("mine.dat");
-            let mine = FileAuraMap::create(mine_file.clone()).unwrap_or_else(|_| {
-                panic!("unable to create mining info file '{}'", mine_file.display())
-            });
+            let index = FileAoraIndex::create_new(&path, "index.dat")?;
+            let stand = FileAoraIndex::create_new(&path, "stand.dat")?;
+            let mine = FileAuraMap::create_new(&path, "mine.dat")?;
 
-            Self {
+            Ok(Self {
                 hoard,
                 cache,
                 keep,
@@ -232,31 +224,24 @@ pub mod fs {
                 stand,
                 mine,
                 _phantom: PhantomData,
-            }
+            })
         }
     }
 
     impl<Seal: RgbSeal> FilePile<Seal>
     where Seal::WitnessId: From<[u8; 32]> + Into<[u8; 32]>
     {
-        pub fn open(path: impl AsRef<Path>) -> Self {
+        pub fn open(path: impl AsRef<Path>) -> io::Result<Self> {
             let path = path.as_ref().to_path_buf();
-            let hoard = FileAoraMap::open(&path, "hoard");
-            let cache = FileAoraMap::open(&path, "cache");
-            let keep = FileAoraMap::open(&path, "keep");
+            let hoard = FileAoraMap::open(&path, "hoard")?;
+            let cache = FileAoraMap::open(&path, "cache")?;
+            let keep = FileAoraMap::open(&path, "keep")?;
 
-            let index_file = path.join("index.dat");
-            let index = FileAoraIndex::open(index_file.clone())
-                .unwrap_or_else(|_| panic!("unable to open index file '{}'", index_file.display()));
-            let stand_file = path.join("stand.dat");
-            let stand = FileAoraIndex::open(stand_file.clone())
-                .unwrap_or_else(|_| panic!("unable to open stand file '{}'", stand_file.display()));
-            let mine_file = path.join("mine.dat");
-            let mine = FileAuraMap::open(mine_file.clone()).unwrap_or_else(|_| {
-                panic!("unable to open mining info file '{}'", mine_file.display())
-            });
+            let index = FileAoraIndex::open(&path, "index.dat")?;
+            let stand = FileAoraIndex::open(&path, "stand.dat")?;
+            let mine = FileAuraMap::open(&path, "mine.dat")?;
 
-            Self {
+            Ok(Self {
                 hoard,
                 cache,
                 keep,
@@ -264,7 +249,7 @@ pub mod fs {
                 stand,
                 mine,
                 _phantom: PhantomData,
-            }
+            })
         }
     }
 

--- a/src/providers/fs.rs
+++ b/src/providers/fs.rs
@@ -1,0 +1,236 @@
+// Standard Library for RGB smart contracts
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Designed in 2019-2025 by Dr Maxim Orlovsky <orlovsky@lnp-bp.org>
+// Written in 2024-2025 by Dr Maxim Orlovsky <orlovsky@lnp-bp.org>
+//
+// Copyright (C) 2019-2024 LNP/BP Standards Association, Switzerland.
+// Copyright (C) 2024-2025 LNP/BP Laboratories,
+//                         Institute for Distributed and Cognitive Systems (InDCS), Switzerland.
+// Copyright (C) 2025 RGB Consortium, Switzerland.
+// Copyright (C) 2019-2025 Dr Maxim Orlovsky.
+// All rights under the above copyrights are reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+use std::io;
+use std::marker::PhantomData;
+use std::path::Path;
+
+use amplify::confinement::SmallOrdMap;
+use aora::file::{FileAoraIndex, FileAoraMap, FileAuraMap};
+use aora::{AoraIndex, AoraMap, AuraMap, TransactionalMap};
+use rgb::RgbSeal;
+use strict_encoding::{StrictDecode, StrictEncode};
+
+use crate::{OpRels, Opid, Pile, Witness, WitnessStatus};
+
+const HOARD_MAGIC: u64 = u64::from_be_bytes(*b"RGBHOARD");
+const CACHE_MAGIC: u64 = u64::from_be_bytes(*b"RGBCACHE");
+const KEEP_MAGIC: u64 = u64::from_be_bytes(*b"RGBKEEPS");
+const INDEX_MAGIC: u64 = u64::from_be_bytes(*b"RGBINDEX");
+const STAND_MAGIC: u64 = u64::from_be_bytes(*b"RGBSTAND");
+const MINE_MAGIC: u64 = u64::from_be_bytes(*b"RGBMINES");
+
+pub struct PileFs<Seal: RgbSeal>
+where Seal::WitnessId: From<[u8; 32]> + Into<[u8; 32]>
+{
+    hoard: FileAoraMap<Seal::WitnessId, Seal::Client, HOARD_MAGIC, 1>,
+    cache: FileAoraMap<Seal::WitnessId, Seal::Published, CACHE_MAGIC, 1>,
+    keep: FileAoraMap<Opid, SmallOrdMap<u16, Seal::Definiton>, KEEP_MAGIC, 1>,
+    index: FileAoraIndex<Opid, Seal::WitnessId, INDEX_MAGIC, 1>,
+    stand: FileAoraIndex<Seal::WitnessId, Opid, STAND_MAGIC, 1>,
+    mine: FileAuraMap<Seal::WitnessId, WitnessStatus, MINE_MAGIC, 1, 32, 8>,
+    _phantom: PhantomData<Seal>,
+}
+
+impl<Seal: RgbSeal> PileFs<Seal>
+where Seal::WitnessId: From<[u8; 32]> + Into<[u8; 32]>
+{
+    pub fn create_new(name: &str, path: impl AsRef<Path>) -> io::Result<Self> {
+        let mut path = path.as_ref().to_path_buf();
+        path.push(name);
+        path.set_extension("contract");
+
+        let hoard = FileAoraMap::create_new(&path, "hoard")?;
+        let cache = FileAoraMap::create_new(&path, "cache")?;
+        let keep = FileAoraMap::create_new(&path, "keep")?;
+
+        let index = FileAoraIndex::create_new(&path, "index.dat")?;
+        let stand = FileAoraIndex::create_new(&path, "stand.dat")?;
+        let mine = FileAuraMap::create_new(&path, "mine.dat")?;
+
+        Ok(Self {
+            hoard,
+            cache,
+            keep,
+            index,
+            stand,
+            mine,
+            _phantom: PhantomData,
+        })
+    }
+}
+
+impl<Seal: RgbSeal> PileFs<Seal>
+where Seal::WitnessId: From<[u8; 32]> + Into<[u8; 32]>
+{
+    pub fn open(path: impl AsRef<Path>) -> io::Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        let hoard = FileAoraMap::open(&path, "hoard")?;
+        let cache = FileAoraMap::open(&path, "cache")?;
+        let keep = FileAoraMap::open(&path, "keep")?;
+
+        let index = FileAoraIndex::open(&path, "index.dat")?;
+        let stand = FileAoraIndex::open(&path, "stand.dat")?;
+        let mine = FileAuraMap::open(&path, "mine.dat")?;
+
+        Ok(Self {
+            hoard,
+            cache,
+            keep,
+            index,
+            stand,
+            mine,
+            _phantom: PhantomData,
+        })
+    }
+}
+
+impl<Seal: RgbSeal> Pile for PileFs<Seal>
+where
+    Seal::Client: StrictEncode + StrictDecode,
+    Seal::Published: Eq + StrictEncode + StrictDecode,
+    Seal::WitnessId: From<[u8; 32]> + Into<[u8; 32]>,
+{
+    type Seal = Seal;
+
+    fn has_witness(&self, wid: Seal::WitnessId) -> bool { self.hoard.contains_key(wid) }
+
+    fn pub_witness(&self, wid: Seal::WitnessId) -> Seal::Published { self.cache.get_expect(wid) }
+
+    fn cli_witness(&self, wid: Seal::WitnessId) -> Seal::Client { self.hoard.get_expect(wid) }
+
+    fn witness_status(&self, wid: Seal::WitnessId) -> WitnessStatus { self.mine.get_expect(wid) }
+
+    fn op_witness_ids(&self, opid: Opid) -> impl ExactSizeIterator<Item = Seal::WitnessId> {
+        self.index.get(opid)
+    }
+
+    fn ops_by_witness_id(&self, wid: Seal::WitnessId) -> impl ExactSizeIterator<Item = Opid> {
+        self.stand.get(wid)
+    }
+
+    fn op_seals(&self, opid: Opid) -> SmallOrdMap<u16, Seal::Definiton> {
+        self.keep.get_expect(opid)
+    }
+
+    fn witnesses_since(
+        &self,
+        transaction_no: u64,
+    ) -> impl Iterator<Item = <Seal as RgbSeal>::WitnessId> {
+        struct WitnessIter<'pile, Id, M>
+        where
+            Id: From<[u8; 32]> + Into<[u8; 32]>,
+            M: AuraMap<Id, WitnessStatus, 32, 8>,
+        {
+            curr: u64,
+            max: u64,
+            mine: &'pile M,
+            iter: Option<Box<dyn Iterator<Item = Id> + 'pile>>,
+            _phantom: PhantomData<Id>,
+        }
+        impl<'pile, Id: 'pile, M> Iterator for WitnessIter<'pile, Id, M>
+        where
+            Id: From<[u8; 32]> + Into<[u8; 32]>,
+            M: AuraMap<Id, WitnessStatus, 32, 8> + TransactionalMap<Id>,
+        {
+            type Item = Id;
+            fn next(&mut self) -> Option<Self::Item> {
+                loop {
+                    match self.iter.as_mut()?.next() {
+                        None => {
+                            self.curr += 1;
+                            if self.curr >= self.max {
+                                return None;
+                            }
+                            self.iter = Some(Box::new(self.mine.transaction_keys(self.curr)));
+                        }
+                        Some(el) => return Some(el),
+                    }
+                }
+            }
+        }
+
+        let to = self.mine.transaction_count();
+
+        let mine = &self.mine;
+        WitnessIter {
+            curr: transaction_no + 1,
+            max: to,
+            mine,
+            iter: Some(Box::new(mine.transaction_keys(transaction_no))),
+            _phantom: PhantomData,
+        }
+    }
+
+    fn add_witness(
+        &mut self,
+        opid: Opid,
+        wid: <Self::Seal as RgbSeal>::WitnessId,
+        published: &<Self::Seal as RgbSeal>::Published,
+        anchor: &<Self::Seal as RgbSeal>::Client,
+    ) {
+        self.index.push(opid, wid);
+        self.stand.push(wid, opid);
+        // TODO: This will panic on the anchor update, which must not happen!
+        self.hoard.insert(wid, anchor);
+        self.cache.insert(wid, published);
+        if !self.mine.contains_key(wid) {
+            self.mine.insert_only(wid, WitnessStatus::Archived);
+        }
+    }
+
+    fn add_seals(
+        &mut self,
+        opid: Opid,
+        seals: SmallOrdMap<u16, <Self::Seal as RgbSeal>::Definiton>,
+    ) {
+        self.keep.insert(opid, &seals)
+    }
+
+    fn update_witness_status(
+        &mut self,
+        wid: <Self::Seal as RgbSeal>::WitnessId,
+        status: WitnessStatus,
+    ) {
+        self.mine.update_only(wid, status);
+    }
+
+    fn commit_transaction(&mut self) { self.mine.commit_transaction(); }
+
+    fn witnesses(&self) -> impl Iterator<Item = Witness<Self::Seal>> {
+        self.hoard.iter().map(|(wid, client)| {
+            let published = self.cache.get_expect(wid);
+            let status = self.mine.get_expect(wid);
+            let opids = self.stand.get(wid).collect();
+            Witness { id: wid, published, client, status, opids }
+        })
+    }
+
+    fn ops(&self) -> impl Iterator<Item = OpRels<Self::Seal>> {
+        self.keep.iter().map(|(opid, seals)| {
+            let witness_ids = self.index.get(opid).collect();
+            OpRels { opid, witness_ids, defines: seals, _phantom: PhantomData }
+        })
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -22,43 +22,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![cfg_attr(not(feature = "std"), no_std)]
-#![allow(clippy::type_complexity)]
+mod fs;
 
-extern crate alloc;
-
-#[macro_use]
-extern crate amplify;
-extern crate rgbcore as rgb;
-
-#[cfg(feature = "bitcoin")]
-#[macro_use]
-extern crate strict_encoding;
-#[cfg(all(feature = "serde", feature = "bitcoin"))]
-#[macro_use]
-extern crate serde;
-
-pub extern crate rgb_invoice as invoice;
-
-mod pile;
-mod contract;
-mod mound;
-mod info;
-pub mod popls;
-mod util;
-pub mod providers;
-
-#[cfg(feature = "bitcoin")]
-pub use bp::{Outpoint, Txid};
-pub use contract::{
-    Assignment, ConsumeError, Contract, CreateParams, EitherSeal, ImmutableState, OwnedState,
-};
-pub use hypersonic::*;
-pub use info::ContractInfo;
 #[cfg(feature = "fs")]
-pub use mound::file::{DirExcavator, DirMound};
-pub use mound::{Excavate, IssueError, Mound, MoundConsumeError, MAGIC_BYTES_CONSIGNMENT};
-pub use pile::{OpRels, Pile, Witness, WitnessStatus};
-pub use rgb::*;
-pub use util::{ContractRef, InvalidContractRef};
+pub use fs::PileFs;


### PR DESCRIPTION
This reduces attack surface my removing many previously exposed internals of the library.

Based on https://github.com/AluVM/sonic/pull/15