### PR TITLE
Fix: Update in-memory contract collection after issuing a contract

### DIFF
--- a/src/stockpile/dir.rs
+++ b/src/stockpile/dir.rs
@@ -160,7 +160,7 @@ where
         let schema = self
             .issuer(params.codex_id)
             .ok_or(IssuerError::UnknownCodex(params.codex_id))?;
-        Ok(Contract::issue(schema, params, |articles| {
+        let contract = Contract::issue(schema, params, |articles| {
             let dir = self.contract_dir(articles);
             if fs::exists(&dir).map_err(|e| IssueError::OtherPersistence(e))? {
                 return Err(IssueError::OtherPersistence(io::Error::other(
@@ -169,6 +169,9 @@ where
             }
             fs::create_dir_all(&dir).map_err(|e| IssueError::OtherPersistence(e))?;
             Ok(dir)
-        })?)
+        })?;
+        self.contracts
+            .insert(contract.contract_id(), contract.articles().issue.meta.name.to_string());
+        Ok(contract)
     }
 }


### PR DESCRIPTION
## Issue Description

In the RGB protocol implementation, when a wallet issues a contract, the contract ID and information are only saved to the filesystem without updating the in-memory `contracts` collection. This causes a problem: the wallet cannot detect its own recently issued contract using the `has_contract` method, which may negatively impact subsequent contract operations.

## Steps to Reproduce

1. Create a wallet instance
2. Issue an NIA asset/contract using the wallet
3. Immediately check if the wallet owns this contract
4. Discover that the contract doesn't exist in memory, despite being successfully issued

Error manifestation:
```rust
// Check after issuing contract
if !wlt_1.runtime.contracts.has_contract(contract_id) {
    panic!("after issue contract not exist");
}
```

This check triggers a panic, indicating that although the contract has been issued, it cannot be found in memory.

## Root Cause

In the `issue` method of `rgb-std/src/stockpile/dir.rs`, after the contract is successfully created and saved to the filesystem, the contract ID and name are not added to the in-memory contract collection. The current code only creates the contract and returns it without updating the memory state.

## Fix

Add code before returning the contract to insert the contract ID and name into the in-memory contract collection:

With this fix, the wallet can immediately detect the existence of the contract after issuing it, maintaining consistency between the memory state and filesystem state. 