### PR TITLE
fix: incorrect witness status in state_all method for RBF scenarios

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -465,10 +465,11 @@ impl<S: Stock, P: Pile> Contract<S, P> {
                 } else {
                     // We insert a copy of state for each of the witnesses created for the operation
                     for wid in self.pile.op_witness_ids(addr.opid) {
+                        let status = self.pile.witness_status(wid);
                         state.push(OwnedState {
                             addr,
                             assignment: Assignment { seal: seal.resolve(wid), data: data.clone() },
-                            status: since,
+                            status,
                         });
                     }
                 }


### PR DESCRIPTION
## PR Description

### Summary

This PR fixes a bug in the `state_all` method where unbroadcasted RBF (Replace-By-Fee) transactions were incorrectly marked with `Mined` status instead of their actual `Archived` status.

### Problem Description

In RBF scenarios, when a sender creates multiple transactions (original + replacement) but only broadcasts one of them, the `state_all` method was returning incorrect witness status for unbroadcasted transactions. Specifically:

- **Expected behavior**: Unbroadcasted transactions should have `Archived` status
- **Actual behavior**: Unbroadcasted transactions were incorrectly showing `Mined` status
- **Impact**: This caused confusion in asset state tracking and debugging

### Root Cause

The issue was in `rgb-std/src/contract.rs` where the state collection logic was not properly querying the actual witness status for each witness ID. Instead, it was using a potentially incorrect or hardcoded status value.

### Solution

**Before (problematic code)**:
```rust
for wid in self.pile.op_witness_ids(addr.opid) {
    state.push(OwnedState {
        addr,
        assignment: Assignment { seal: seal.resolve(wid), data: data.clone() },
        status: since, //  Using incorrect status
    });
}
```

**After (fixed code)**:
```rust
for wid in self.pile.op_witness_ids(addr.opid) {
    let status = self.pile.witness_status(wid); //  Query actual witness status
    state.push(OwnedState {
        addr,
        assignment: Assignment { seal: seal.resolve(wid), data: data.clone() },
        status, //  Use actual witness status
    });
}
```