### PR TITLE
Improve accounting for the witness status in the history

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -372,12 +372,15 @@ impl<S: Stock, P: Pile> Contract<S, P> {
 
     /// Get the best mining status for a given operation ("best" means "the most deeply mined").
     fn witness_status(&self, opid: Opid) -> WitnessStatus {
+        if self.articles().genesis_opid() == opid {
+            return WitnessStatus::Genesis;
+        }
         self.pile
             .op_witness_ids(opid)
             .map(|wid| self.pile.witness_status(wid))
             // "best" means "the most deeply mined", i.e., minimal
             .min()
-            .unwrap_or(WitnessStatus::Genesis)
+            .unwrap_or(WitnessStatus::Archived)
     }
 
     fn retrieve(&self, opid: Opid) -> Option<SealWitness<P::Seal>> {

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -370,12 +370,13 @@ impl<S: Stock, P: Pile> Contract<S, P> {
         Ok(Self { ledger, pile, contract_id })
     }
 
-    /// Get mining status for a given operation.
+    /// Get the best mining status for a given operation ("best" means "the most deeply mined").
     fn witness_status(&self, opid: Opid) -> WitnessStatus {
         self.pile
             .op_witness_ids(opid)
             .map(|wid| self.pile.witness_status(wid))
-            .max()
+            // "best" means "the most deeply mined", i.e., minimal
+            .min()
             .unwrap_or(WitnessStatus::Genesis)
     }
 
@@ -384,7 +385,7 @@ impl<S: Stock, P: Pile> Contract<S, P> {
             .pile
             .op_witness_ids(opid)
             .map(|wid| (self.pile.witness_status(wid), wid))
-            .max()?;
+            .min()?;
         if !status.is_valid() {
             return None;
         }

--- a/src/pile.rs
+++ b/src/pile.rs
@@ -199,11 +199,6 @@ pub trait Pile {
 
     fn witnesses(&self) -> impl Iterator<Item = Witness<Self::Seal>>;
 
-    fn witnesses_since(
-        &self,
-        transaction_no: u64,
-    ) -> impl Iterator<Item = <Self::Seal as RgbSeal>::WitnessId>;
-
     fn op_witness_ids(
         &self,
         opid: Opid,


### PR DESCRIPTION
Right now owned state reports just a state of its own witness mining.

However, it is desirable to know the worst confirmation in the whole of the history leading to the state.

This is purely UI enhancement (since invalid state is anyway excluded due to rollback procedure).