### PR TITLE
Implement efficient sync procedure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, ubuntu-latest, macos-13, macos-latest, windows-2019, windows-latest ]
+        os: [ ubuntu-22.04, ubuntu-latest, macos-13, macos-latest, windows-2022, windows-latest ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -103,33 +103,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "baid64"
@@ -357,24 +357,24 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cc"
-version = "1.2.25"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -403,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -415,27 +415,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "commit_encoding_derive"
@@ -581,7 +581,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -674,9 +674,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "log"
@@ -719,9 +719,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "minicov"
@@ -801,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -881,7 +881,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1043,7 +1043,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1060,9 +1060,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -1301,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1327,14 +1327,14 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "toml"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1344,18 +1344,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
@@ -1367,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "toml_write"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "typenum"
@@ -1441,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1476,7 +1476,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -1511,7 +1511,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1546,7 +1546,7 @@ checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1589,7 +1589,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1600,14 +1600,14 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -1702,9 +1702,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -1720,22 +1720,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,3 +124,6 @@ features = ["all"]
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(coverage_nightly)'] }
+
+[patch.crates-io]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,5 +125,3 @@ features = ["all"]
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(coverage_nightly)'] }
 
-[patch.crates-io]
-

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -104,7 +104,7 @@ where
         } else if let Some(or) = or {
             or
         } else {
-            panic!("Contract {} not found", id)
+            panic!("Contract {id} not found")
         }
     }
 
@@ -123,7 +123,7 @@ where
             self.contracts.borrow_mut().insert(id, contract);
             res
         } else {
-            panic!("Contract {} not found", id)
+            panic!("Contract {id} not found")
         }
     }
 }

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -34,6 +34,7 @@ use commit_verify::StrictHash;
 use hypersonic::{
     AcceptError, AuthToken, CallParams, CodexId, ContractId, ContractName, Opid, Stock,
 };
+use indexmap::{IndexMap, IndexSet};
 use rgb::RgbSeal;
 use strict_encoding::{
     ReadRaw, StrictDecode, StrictDumb, StrictEncode, StrictReader, StrictWriter, WriteRaw,
@@ -58,6 +59,7 @@ pub use _fs::CONSIGN_MAGIC_NUMBER;
 #[derive(Clone, Debug)]
 pub struct Contracts<
     Sp,
+    // TODO: Use IndexMap instead to be no_std-compatible
     S = HashMap<CodexId, Issuer>,
     C = HashMap<ContractId, Contract<<Sp as Stockpile>::Stock, <Sp as Stockpile>::Pile>>,
 > where
@@ -208,24 +210,6 @@ where
         }
     }
 
-    /// Iterates over all witness ids known to the set of contracts.
-    ///
-    /// # Nota bene
-    ///
-    /// Iterator may repeat the same id multiple times.
-    pub fn witness_ids(
-        &self,
-    ) -> impl Iterator<Item = <<Sp::Pile as Pile>::Seal as RgbSeal>::WitnessId> + use<'_, Sp, S, C>
-    {
-        self.persistence.contract_ids().flat_map(move |id| {
-            self.with_contract(
-                id,
-                |contract| contract.witness_ids().collect::<Vec<_>>(),
-                Some(none!()),
-            )
-        })
-    }
-
     pub fn import_issuer(&mut self, issuer: Issuer) -> Result<CodexId, Sp::Error> {
         let codex_id = issuer.codex_id();
         let schema = self.persistence.import_issuer(issuer)?;
@@ -288,24 +272,36 @@ where
 
     /// Synchronize the status of all witnesses and single-use seal definitions.
     ///
-    /// # Panics
-    ///
-    /// If the contract id is not known.
-    pub fn sync<'a, I>(
+    /// Applies rollbacks or forwards if required and recomputes the state of the affected
+    /// contracts.
+    pub fn sync_witnesses<E: core::error::Error>(
         &mut self,
-        changed: I,
-    ) -> Result<(), MultiError<AcceptError, <Sp::Stock as Stock>::Error>>
-    where
-        I: IntoIterator<
-                Item = (&'a <<Sp::Pile as Pile>::Seal as RgbSeal>::WitnessId, &'a WitnessStatus),
-            > + Copy,
-        <<Sp::Pile as Pile>::Seal as RgbSeal>::WitnessId: 'a,
-    {
-        let contract_ids = self.persistence.contract_ids().collect::<Vec<_>>();
-        for contract_id in &contract_ids {
-            self.with_contract_mut(*contract_id, |contract| {
-                contract.sync(changed.into_iter().map(|(id, status)| (*id, *status)))
-            })?;
+        resolver: impl Fn(<<Sp::Pile as Pile>::Seal as RgbSeal>::WitnessId) -> Result<WitnessStatus, E>,
+    ) -> Result<(), MultiError<SyncError<E>, <Sp::Stock as Stock>::Error>> {
+        let mut changed_statuses = IndexMap::<_, WitnessStatus>::new();
+        let contract_ids = self.persistence.contract_ids().collect::<IndexSet<_>>();
+        for contract_id in contract_ids {
+            self.with_contract_mut(
+                contract_id,
+                |contract| -> Result<(), MultiError<SyncError<E>, <Sp::Stock as Stock>::Error>> {
+                    for witness_id in contract.witness_ids() {
+                        let new_status = match changed_statuses.get(&witness_id) {
+                            None => resolver(witness_id)
+                                .map_err(SyncError::Status)
+                                .map_err(MultiError::A),
+                            Some(witness_id) => Ok(*witness_id),
+                        }?;
+                        let old_status = contract.witness_status(witness_id);
+                        if new_status != old_status {
+                            changed_statuses.insert(witness_id, new_status);
+                        }
+                    }
+                    contract
+                        .sync(changed_statuses.iter().map(|(id, status)| (*id, *status)))
+                        .map_err(MultiError::from_other_a)?;
+                    Ok(())
+                },
+            )?;
         }
         Ok(())
     }
@@ -591,4 +587,18 @@ mod _fs {
             self.consume(allow_unknown, &mut reader, seal_resolver, sig_validator)
         }
     }
+}
+
+#[derive(Debug, Display, Error, From)]
+#[display(doc_comments)]
+pub enum SyncError<E: core::error::Error> {
+    /// unable to synchronize wallet. Details: {0}
+    Wallet(E),
+
+    /// unable to retrieve the status of a witness id. Details: {0}
+    Status(E),
+
+    #[from]
+    #[display(inner)]
+    Forward(AcceptError),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub use contract::{
 };
 #[cfg(feature = "binfile")]
 pub use contracts::CONSIGN_MAGIC_NUMBER;
-pub use contracts::{Contracts, IssuerError, CONSIGN_VERSION};
+pub use contracts::{Contracts, IssuerError, SyncError, CONSIGN_VERSION};
 pub use hypersonic::*;
 pub use pile::{OpRels, Pile, Witness, WitnessStatus};
 pub use rgb::*;

--- a/src/popls/bp.rs
+++ b/src/popls/bp.rs
@@ -37,7 +37,7 @@ use amplify::{confinement, ByteArray, Bytes32, MultiError, Wrapper};
 use bp::dbc::tapret::TapretProof;
 pub use bp::seals;
 use bp::seals::{mmb, Anchor, Noise, TxoSeal, TxoSealExt, WOutpoint, WTxoSeal};
-use bp::{Outpoint, Sats, ScriptPubkey, Tx, Vout};
+use bp::{Outpoint, Sats, ScriptPubkey, Tx, Txid, Vout};
 use commit_verify::mpc::ProtocolId;
 use commit_verify::{mpc, Digest, DigestExt, Sha256, StrictHash};
 use hypersonic::{
@@ -52,23 +52,33 @@ use rgbcore::LIB_NAME_RGB;
 use strict_encoding::{ReadRaw, StrictDecode, StrictReader, TypeName};
 use strict_types::StrictVal;
 
+use crate::contracts::SyncError;
 use crate::{
     Assignment, CodexId, Consensus, ConsumeError, Contract, ContractState, Contracts, CreateParams,
-    EitherSeal, Identity, Issuer, IssuerError, OwnedState, Pile, SigBlob, Stockpile,
+    EitherSeal, Identity, Issuer, IssuerError, OwnedState, Pile, SigBlob, Stockpile, WitnessStatus,
 };
 
 /// Trait abstracting a specific implementation of a bitcoin wallet.
 pub trait WalletProvider {
-    fn noise_seed(&self) -> Bytes32;
+    type SyncError: core::error::Error;
+
     fn has_utxo(&self, outpoint: Outpoint) -> bool;
     fn utxos(&self) -> impl Iterator<Item = Outpoint>;
+    fn sync_utxos(&mut self) -> Result<(), Self::SyncError>;
+
     fn register_seal(&mut self, seal: WTxoSeal);
     fn resolve_seals(
         &self,
         seals: impl Iterator<Item = AuthToken>,
     ) -> impl Iterator<Item = WTxoSeal>;
+
+    fn noise_seed(&self) -> Bytes32;
     fn next_address(&mut self) -> Address;
     fn next_nonce(&mut self) -> u64;
+
+    /// Returns a closure which can retrieve a witness status of an arbitrary transaction id
+    /// (including the ones that are not related to the wallet).
+    fn txid_resolver(&self) -> impl Fn(Txid) -> Result<WitnessStatus, Self::SyncError>;
 }
 
 pub trait Coinselect {
@@ -367,9 +377,9 @@ impl PrefabBundle {
     }
 }
 
-/// Barrow contains a bunch of RGB contracts, which are held by a single owner (a wallet); such that
-/// when a new operation under any of the contracts happens, it may affect other contracts sharing
-/// the same UTXOs.
+/// RGB wallet contains a bunch of RGB contracts, which are held by a single owner (a wallet);
+/// such that when a new operation under any of the contracts happens, it may affect other contracts
+/// sharing the same UTXOs.
 pub struct RgbWallet<
     W,
     Sp,
@@ -829,6 +839,23 @@ where
         };
         self.contracts
             .consume(allow_unknown, reader, seal_resolver, sig_validator)
+    }
+
+    /// Synchronize a wallet UTXO set and the status of all witnesses and single-use seal
+    /// definitions.
+    ///
+    /// Applies rollbacks or forwards if required and recomputes the state of the affected
+    /// contracts.
+    pub fn sync(
+        &mut self,
+    ) -> Result<(), MultiError<SyncError<W::SyncError>, <Sp::Stock as Stock>::Error>> {
+        self.wallet
+            .sync_utxos()
+            .map_err(SyncError::Wallet)
+            .map_err(MultiError::from_a)?;
+        self.contracts
+            .sync_witnesses(self.wallet.txid_resolver())
+            .map_err(MultiError::from_other_a)
     }
 }
 

--- a/src/popls/bp.rs
+++ b/src/popls/bp.rs
@@ -383,6 +383,7 @@ impl PrefabBundle {
 pub struct RgbWallet<
     W,
     Sp,
+    // TODO: Replace with IndexMap
     S = HashMap<CodexId, Issuer>,
     C = HashMap<ContractId, Contract<<Sp as Stockpile>::Stock, <Sp as Stockpile>::Pile>>,
 > where
@@ -404,9 +405,11 @@ where
     S: KeyedCollection<Key = CodexId, Value = Issuer>,
     C: KeyedCollection<Key = ContractId, Value = Contract<Sp::Stock, Sp::Pile>>,
 {
-    pub fn with(wallet: W, contracts: Contracts<Sp, S, C>) -> Self { Self { wallet, contracts } }
+    pub fn with_components(wallet: W, contracts: Contracts<Sp, S, C>) -> Self {
+        Self { wallet, contracts }
+    }
 
-    pub fn unbind(self) -> (W, Contracts<Sp, S, C>) { (self.wallet, self.contracts) }
+    pub fn into_components(self) -> (W, Contracts<Sp, S, C>) { (self.wallet, self.contracts) }
 
     pub fn issue(
         &mut self,


### PR DESCRIPTION
This PR moves sync method from `rgb` repo to `rgb-std`, making its implementation efficient and fully abstracted from a specific wallet provider and indexer